### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![smithery badge](https://smithery.ai/badge/@knowall-ai/mcp-neo4j-agent-memory)](https://smithery.ai/server/@knowall-ai/mcp-neo4j-agent-memory)
+[![LightNow](https://lightnow.ai/badge/io.github.knowall-ai/mcp-neo4j-agent-memory)](https://lightnow.ai/servers/io.github.knowall-ai/mcp-neo4j-agent-memory)
 
 # Neo4j Agent Memory MCP Server
 
@@ -131,7 +131,7 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 
 ### Installing via Smithery
 
-[![smithery badge](https://smithery.ai/badge/@knowall-ai/mcp-neo4j-agent-memory)](https://smithery.ai/server/@knowall-ai/mcp-neo4j-agent-memory)
+[![LightNow](https://lightnow.ai/badge/io.github.knowall-ai/mcp-neo4j-agent-memory)](https://lightnow.ai/servers/io.github.knowall-ai/mcp-neo4j-agent-memory)
 
 To install Neo4j Agent Memory MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@knowall-ai/mcp-neo4j-agent-memory):
 


### PR DESCRIPTION
## Summary

Replaces the broken Smithery badge with the matching LightNow capability badge.

- Server: https://lightnow.ai/servers/io.github.knowall-ai/mcp-neo4j-agent-memory
- Badge docs and variants: https://docs.lightnow.ai/how-to/add-capability-badge/

## Validation

- Verified the badge SVG and server page return successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Replaces the broken Smithery badge with the LightNow capability badge in `README.md`. Both badge instances link to the LightNow MCP server.

### Worth a look

- **Cleanup:** Confirm that the LightNow server, badge SVG, and documentation links resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->