### PR TITLE
ci: add CI, gitleaks, PR lint, PR template and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner — applies to the entire repo
+*   @BenGWeeks

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Title format: conventional-commit prefix + short description.
 
 Fixes #
 
-<!-- One `Fixes #nnn` per issue resolved. Required for feat/fix/perf/refactor; optional for every other prefix (chore, ci, docs, deps, test, build, style) — delete the section if unused. -->
+<!-- At least one `Fixes #nnn` line is required for feat/fix/perf/refactor (the lint checks for one; list every issue you resolve). Optional for every other prefix (chore, ci, docs, deps, test, build, style) — delete the section if unused. -->
 
 ## Test plan
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Title format: conventional-commit prefix + short description.
+  feat: ...      fix: ...      perf: ...      refactor: ...     (require Fixes #nnn)
+  chore: ...     ci: ...       docs: ...      deps: ...
+  test: ...      build: ...    style: ...
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what changed and why. -->
+
+## Fixes
+
+Fixes #
+
+<!-- One `Fixes #nnn` per issue resolved. Delete this section for chore/ci/docs/deps PRs. -->
+
+## Test plan
+
+<!--
+Steps a reviewer can follow, with expected results, e.g.
+  1. `npm run build && npm run test:unit`
+  2. Start Neo4j 5 with APOC, copy `.env.example` to `.env`, run `npm test`.
+  3. **Expected:** every test reports "completed successfully".
+For refactor / docs / CI / deps PRs: N/A — <reason>
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Title format: conventional-commit prefix + short description.
 
 Fixes #
 
-<!-- One `Fixes #nnn` per issue resolved. Delete this section for chore/ci/docs/deps PRs. -->
+<!-- One `Fixes #nnn` per issue resolved. Required for feat/fix/perf/refactor; optional for every other prefix (chore, ci, docs, deps, test, build, style) — delete the section if unused. -->
 
 ## Test plan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -27,10 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run test:unit --if-present
+      - run: npm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:unit --if-present

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0   # full history: secrets committed and later removed must still be found
       - name: Install and run gitleaks
         env:
           GITLEAKS_VERSION: 8.30.1
@@ -23,4 +24,4 @@ jobs:
           grep -E " gitleaks_${GITLEAKS_VERSION}_linux_x64\.tar\.gz$" checksums.txt > archive.sha256
           sha256sum --check --strict archive.sha256
           tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
-          ./gitleaks dir . --no-banner --redact --exit-code 1
+          ./gitleaks git . --no-banner --redact --exit-code 1

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,6 +19,8 @@ jobs:
           base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
           curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o checksums.txt
-          sha256sum --check --ignore-missing checksums.txt
+          # require the exact entry for our archive; a checksums file that omits it must fail, not pass
+          grep -E " gitleaks_${GITLEAKS_VERSION}_linux_x64\.tar\.gz$" checksums.txt > archive.sha256
+          sha256sum --check --strict archive.sha256
           tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
           ./gitleaks dir . --no-banner --redact --exit-code 1

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,19 @@
+name: gitleaks
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install and run gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gl.tar.gz
+          tar -xzf gl.tar.gz gitleaks
+          ./gitleaks dir . --no-banner --redact --exit-code 1

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,10 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install and run gitleaks
         env:
           GITLEAKS_VERSION: 8.30.1
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gl.tar.gz
-          tar -xzf gl.tar.gz gitleaks
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o checksums.txt
+          sha256sum --check --ignore-missing checksums.txt
+          tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
           ./gitleaks dir . --no-banner --redact --exit-code 1

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,44 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-lint:
+    name: Title, body and issue link
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title, body and issue reference
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -u
+          if [ "$GITHUB_ACTOR" = 'dependabot[bot]' ] || [ "$GITHUB_ACTOR" = 'github-actions[bot]' ]; then
+            echo "Skipping PR lint for bot actor: $GITHUB_ACTOR"; exit 0
+          fi
+          fail=0
+          title_regex='^(feat|fix|perf|refactor|chore|ci|docs|deps|test|build|style): .+'
+          if ! echo "$PR_TITLE" | grep -Eq "$title_regex"; then
+            echo "::error::PR title must start with a conventional-commit prefix (feat:, fix:, chore:, docs:, ...). Got: '$PR_TITLE'"; fail=1
+          fi
+          body_len=$(echo -n "${PR_BODY:-}" | wc -c)
+          if [ "$body_len" -lt 40 ]; then
+            echo "::error::PR body is missing or too short (<40 chars)."; fail=1
+          fi
+          if echo "$PR_TITLE" | grep -Eq '^(feat|fix|perf|refactor): '; then
+            if ! echo "$PR_BODY" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*Fixes #[0-9]+'; then
+              echo "::error::PR body must contain a 'Fixes #nnn' line for feat/fix/perf/refactor PRs."; fail=1
+            fi
+          fi
+          if ! echo "$PR_BODY" | grep -Eq '^## Test plan'; then
+            echo "::error::PR body must include a '## Test plan' section."; fail=1
+          fi
+          [ "$fail" -ne 0 ] && exit 1
+          echo "PR lint passed."

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -28,7 +28,7 @@ jobs:
           if ! echo "$PR_TITLE" | grep -Eq "$title_regex"; then
             echo "::error::PR title must start with a conventional-commit prefix (feat:, fix:, chore:, docs:, ...). Got: '$PR_TITLE'"; fail=1
           fi
-          body_len=$(echo -n "${PR_BODY:-}" | wc -c)
+          body_len=$(echo -n "${PR_BODY:-}" | LC_ALL=C.UTF-8 wc -m)   # characters, not bytes
           if [ "$body_len" -lt 40 ]; then
             echo "::error::PR body is missing or too short (<40 chars)."; fail=1
           fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -37,8 +37,16 @@ jobs:
               echo "::error::PR body must contain a 'Fixes #nnn' line for feat/fix/perf/refactor PRs."; fail=1
             fi
           fi
-          if ! echo "$PR_BODY" | grep -Eq '^## Test plan'; then
+          # The template inserts the heading, so require real content under it (comments stripped);
+          # "N/A" alone is not a plan, it needs a reason.
+          body_clean=$(printf '%s' "${PR_BODY:-}" | perl -0pe 's/<!--.*?-->//gs')
+          plan=$(printf '%s\n' "$body_clean" | awk '/^## Test plan/{flag=1; next} /^## /{flag=0} flag' | tr -d '[:space:]')
+          if ! printf '%s' "$body_clean" | grep -Eq '^## Test plan'; then
             echo "::error::PR body must include a '## Test plan' section."; fail=1
+          elif [ -z "$plan" ]; then
+            echo "::error::The '## Test plan' section is empty; describe how the change was verified."; fail=1
+          elif printf '%s' "$plan" | grep -Eqi '^(n/?a|none)[[:punct:]]*$'; then
+            echo "::error::'N/A' needs a reason (e.g. 'N/A — documentation only')."; fail=1
           fi
           [ "$fail" -ne 0 ] && exit 1
           echo "PR lint passed."

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -40,8 +40,9 @@ jobs:
           # The template inserts the heading, so require real content under it (comments stripped);
           # "N/A" alone is not a plan, it needs a reason.
           body_clean=$(printf '%s' "${PR_BODY:-}" | perl -0pe 's/<!--.*?-->//gs')
-          plan=$(printf '%s\n' "$body_clean" | awk '/^## Test plan/{flag=1; next} /^## /{flag=0} flag' | tr -d '[:space:]')
-          if ! printf '%s' "$body_clean" | grep -Eq '^## Test plan'; then
+          # exact heading only: "## Test plans" or "## Test plan (old)" must not satisfy the gate
+          plan=$(printf '%s\n' "$body_clean" | awk '/^## Test plan[[:space:]]*$/{flag=1; next} /^## /{flag=0} flag' | tr -d '[:space:]')
+          if ! printf '%s' "$body_clean" | grep -Eq '^## Test plan[[:space:]]*$'; then
             echo "::error::PR body must include a '## Test plan' section."; fail=1
           elif [ -z "$plan" ]; then
             echo "::error::The '## Test plan' section is empty; describe how the change was verified."; fail=1

--- a/tests/test-server-startup.js
+++ b/tests/test-server-startup.js
@@ -101,15 +101,12 @@ async function runTest(config) {
       processExited = true;
       
       if (config.shouldStart) {
-        if (code === 0 || stderr.includes('Neo4j MCP server running on stdio')) {
-          console.log('   ✅ Server started successfully');
-          resolve(true);
-        } else {
-          console.log('   ❌ Server failed to start');
-          console.log('   Exit code:', code);
-          console.log('   Stderr:', stderr);
-          resolve(false);
-        }
+        // A server that is expected to start must still be running when the startup interval
+        // ends; any exit before then, even a clean one, is a failure.
+        console.log('   ❌ Server exited before the startup interval ended');
+        console.log('   Exit code:', code);
+        console.log('   Stderr:', stderr);
+        resolve(false);
       } else {
         if (code !== 0 && config.expectedError && stderr.includes(config.expectedError)) {
           console.log(`   ✅ Server correctly failed with expected error: "${config.expectedError}"`);

--- a/tests/test-server-startup.js
+++ b/tests/test-server-startup.js
@@ -88,6 +88,7 @@ async function runTest(config) {
     let stdout = '';
     let stderr = '';
     let processExited = false;
+    let expectedExit = false; // set just before we kill a server that started correctly
     
     child.stdout.on('data', (data) => {
       stdout += data.toString();
@@ -101,6 +102,7 @@ async function runTest(config) {
       processExited = true;
       
       if (config.shouldStart) {
+        if (expectedExit) return; // our own kill after a successful start
         // A server that is expected to start must still be running when the startup interval
         // ends; any exit before then, even a clean one, is a failure.
         console.log('   ❌ Server exited before the startup interval ended');
@@ -125,6 +127,7 @@ async function runTest(config) {
       setTimeout(() => {
         if (!processExited) {
           // Server is still running, that's good
+          expectedExit = true;
           child.kill();
           console.log('   ✅ Server started successfully');
           resolve(true);

--- a/tests/test-server-startup.js
+++ b/tests/test-server-startup.js
@@ -126,11 +126,16 @@ async function runTest(config) {
     if (config.shouldStart) {
       setTimeout(() => {
         if (!processExited) {
-          // Server is still running, that's good
+          // Server is still running, that's good. Stop it and wait for it to close (bounded) so the
+          // next configuration never starts while this child is still alive.
           expectedExit = true;
+          const killTimer = setTimeout(() => child.kill('SIGKILL'), 3000);
+          child.once('close', () => {
+            clearTimeout(killTimer);
+            console.log('   ✅ Server started successfully');
+            resolve(true);
+          });
           child.kill();
-          console.log('   ✅ Server started successfully');
-          resolve(true);
         }
       }, 2000);
     }


### PR DESCRIPTION
## Summary

- `ci.yml`: Build and Unit Tests jobs on Node 22 (`npm ci`, `npm run build`, `npm run test:unit --if-present`) for every PR and push to `main`.
- `gitleaks.yml`: secret scan, same as poppie-hermes and sallie-openclaw.
- `pr-lint.yml`: conventional-commit title, body of 40+ chars, `Fixes #nnn` for feat/fix/perf/refactor, and a `## Test plan` section, same rules as agents-portal.
- `PULL_REQUEST_TEMPLATE.md` and `CODEOWNERS` (@BenGWeeks).

Once merged, branch protection on `main` should require Build, Unit Tests, gitleaks and "Title, body and issue link".

## Test plan

N/A — CI configuration. The checks run on this PR itself; expected: all four green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds CI, secret scanning, pull request linting, ownership rules, and a pull request template. It also makes server startup tests distinguish expected shutdowns from unexpected exits.

## Worth a look

- `.github/workflows/gitleaks.yml`: Confirm that downloading and verifying Gitleaks v8.30.1 at runtime is acceptable, or pin and cache the tool through a maintained action.
- `.github/workflows/pr-lint.yml`: Confirm that exact `## Test plan` matching and the required `Fixes `#nnn`` rules fit all expected pull request formats.
- `tests/test-server-startup.js`: Review the three-second `SIGKILL` fallback. It prevents hanging tests but can mask slow shutdowns.
- `.github/workflows/ci.yml`: Confirm that separate build and unit-test jobs provide the intended branch-protection checks, rather than combining them into one job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->