### PR TITLE
feat: hybrid semantic search, pluggable embeddings, query/stats/dream tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,7 @@ Unlike traditional approaches that embed complex logic in tools, this server pro
 - **Maximum flexibility**: The LLM can implement any strategy without tool limitations
 
 ### Search Behavior
-The `search_memories` tool uses word tokenization:
-- Query "John Smith" finds memories containing "John" OR "Smith"
-- This returns more results, letting the LLM pick the most relevant
-- Better than exact substring matching for names and multi-word queries
+`search_memories` is hybrid: keyword hits (any word of the query as a substring of any property) rank first, then semantic matches above a similarity threshold. See **Search** below.
 
 This approach makes the system more powerful and adaptable, as improvements in LLM capabilities directly translate to better memory management.
 

--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 
 - `query_memories`: Run a read-only Cypher query
   - Accepts a Cypher string plus optional params
-  - Rejects write operations and caps output at 200 rows
+  - Runs in a Neo4j READ transaction (the server rejects writes), stops after 200 rows, and times out after 10 seconds
+  - Rejects write clauses, `CALL` subqueries, and any procedure outside a small read-only allow-list (`db.labels`, `db.propertyKeys`, `db.index.*.query*`, schema procedures). For belt and braces, run the server with a read-only Neo4j role where you can
 
 - `memory_stats`: Summarize the current graph
   - Returns node, relationship, label, relationship-type, embedding, and orphan counts
 
 - `dream`: Deterministically clean up and consolidate the graph
-  - Relabels lowercase labels to their Capitalised form (`person` → `Person`), merges duplicate names within a label when APOC is available, and refreshes embeddings
+  - Relabels lowercase labels to their Capitalised form (`person` → `Person`), merges same-named nodes within a label when APOC is available, and refreshes embeddings
+  - Merging keeps the survivor's `name`, timestamps and vectors and combines every other property (conflicting values become lists, nothing is dropped) and skips pairs whose identity fields differ (`email`, `phone`, `website`, `company`, `organisation`, `organization`), so two different "John Smith"s stay separate. The report lists every group under `duplicates` with what was merged and what was skipped and why. Run with `dry_run: true` first to review
   - Reports `bloated` nodes (more than `REVERIE_MAX_PROPERTIES`, default 30, real properties) with the keys that look like dated facts or prose, so a nightly sleep can fold them into attributes, relationships or notes
   - Supports `dry_run` for a no-write report
 
@@ -210,7 +212,7 @@ Set `REVERIE_EMBEDDINGS` to choose the embedding provider used by hybrid and sem
 | `voyage` | `voyage-3-lite` | `VOYAGE_API_KEY` |
 | `none` | disabled | none |
 
-Use `REVERIE_EMBEDDING_MODEL` to override the model name for any provider. Remote providers batch up to 64 texts per request.
+Use `REVERIE_EMBEDDING_MODEL` to override the model name for any provider. Remote providers batch up to 64 texts per request, time out after `REVERIE_EMBED_TIMEOUT_MS` (default 30000, max 120000), and must be reached over https; plain http is only accepted for localhost.
 
 The `local` provider downloads its model (about 23 MB) from Hugging Face on first use and caches it. If that download fails, or any provider errors, search degrades to keyword matching for that call and the error is logged to stderr. Set `REVERIE_EMBEDDINGS=none` to turn embeddings off entirely.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
   - Build complex knowledge networks
 
 - `update_memory`: Update properties of existing memories
+  - Returns a `_hint` when the node exceeds the property limit: the graph is for entities and relationships, not a notebook
   - Add or modify any property
   - Set properties to null to remove them
 
@@ -134,6 +135,7 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 
 - `dream`: Deterministically clean up and consolidate the graph
   - Relabels lowercase labels to their Capitalised form (`person` → `Person`), merges duplicate names within a label when APOC is available, and refreshes embeddings
+  - Reports `bloated` nodes (more than `REVERIE_MAX_PROPERTIES`, default 30, real properties) with the keys that look like dated facts or prose, so a nightly sleep can fold them into attributes, relationships or notes
   - Supports `dry_run` for a no-write report
 
 - `get_guidance`: Get help on using the memory tools effectively

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ The `search_memories` tool uses word tokenization:
 
 This approach makes the system more powerful and adaptable, as improvements in LLM capabilities directly translate to better memory management.
 
+## Search
+
+`search_memories` now supports three modes:
+- `hybrid` (default): keyword hits score `1`, then semantic matches add close variants such as `Benjamin Weeks` for `Ben Weeks`
+- `keyword`: preserves today's substring-style word matching across all properties
+- `semantic`: uses embeddings only when available, with graceful fallback to keyword behavior if embeddings are unavailable
+
+Use `similarity_threshold` (default `0.4`, clamped to `0..1`) to control how strict semantic matches are. Results include `_score` and `_match` on each returned `memory` object so callers can explain why a memory was returned.
+
 ### Neo4j Enterprise Support
 
 This server now supports connecting to specific databases in Neo4j Enterprise Edition. By default, it connects to the "neo4j" database, but you can specify a different database using the `NEO4J_DATABASE` environment variable.
@@ -79,12 +88,11 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 ### Memory Tools
 
 - `search_memories`: Search and retrieve memories from the knowledge graph
-  - **Word-based search**: Searches for ANY word in your query (e.g., "Ben Weeks" finds memories containing "Ben" OR "Weeks")
-  - Natural language search across all memory properties (or leave empty to get all)
-  - Filter by memory type (person, place, project, etc.)
-  - Filter by date with `since_date` parameter (ISO format)
-  - Control relationship depth and result limits
-  - Sort by any field (created_at, name, etc.)
+  - **Hybrid search**: Blend keyword and semantic search; `Ben Weeks` can also find `Benjamin Weeks`
+  - Choose `search_mode` = `hybrid`, `keyword`, or `semantic`
+  - Tune semantic strictness with `similarity_threshold` (default `0.4`)
+  - Returned memories include `_score` and `_match` metadata
+  - Filter by memory type (case-insensitive, so `person` and `Person` both work), date, depth, result limit, and sort order
 
 - `create_memory`: Create a new memory in the knowledge graph
   - Flexible type system - use any label in lowercase (person, place, project, skill, etc.)
@@ -116,6 +124,17 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
   - Shows all labels with counts
   - Helps maintain consistency
   - Prevents duplicate label variations
+
+- `query_memories`: Run a read-only Cypher query
+  - Accepts a Cypher string plus optional params
+  - Rejects write operations and caps output at 200 rows
+
+- `memory_stats`: Summarize the current graph
+  - Returns node, relationship, label, relationship-type, embedding, and orphan counts
+
+- `dream`: Deterministically clean up and consolidate the graph
+  - Relabels lowercase labels to their Capitalised form (`person` → `Person`), merges duplicate names within a label when APOC is available, and refreshes embeddings
+  - Supports `dry_run` for a no-write report
 
 - `get_guidance`: Get help on using the memory tools effectively
   - Topics: labels, relationships, best-practices, examples
@@ -175,6 +194,25 @@ The server requires the following environment variables:
 - `NEO4J_USERNAME`: Neo4j username (required)
 - `NEO4J_PASSWORD`: Neo4j password (required)
 - `NEO4J_DATABASE`: Neo4j database name (optional) - For Neo4j Enterprise with multiple databases
+
+## Embeddings
+
+Set `REVERIE_EMBEDDINGS` to choose the embedding provider used by hybrid and semantic search. Changing `REVERIE_EMBEDDINGS` or `REVERIE_EMBEDDING_MODEL` causes nodes to be re-embedded lazily on the next search, or eagerly when you run `dream`.
+
+| `REVERIE_EMBEDDINGS` | Default model | Required env vars |
+| --- | --- | --- |
+| `local` (default) | `Xenova/all-MiniLM-L6-v2` | none; optional `REVERIE_MODEL_CACHE` |
+| `openai` | `text-embedding-3-small` | `OPENAI_API_KEY`; optional `OPENAI_BASE_URL` |
+| `azure` | deployment-backed | `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_EMBEDDING_DEPLOYMENT`; optional `AZURE_OPENAI_API_VERSION` |
+| `ollama` | `nomic-embed-text` | optional `OLLAMA_HOST` |
+| `voyage` | `voyage-3-lite` | `VOYAGE_API_KEY` |
+| `none` | disabled | none |
+
+Use `REVERIE_EMBEDDING_MODEL` to override the model name for any provider. Remote providers batch up to 64 texts per request.
+
+The `local` provider downloads its model (about 23 MB) from Hugging Face on first use and caches it. If that download fails, or any provider errors, search degrades to keyword matching for that call and the error is logged to stderr. Set `REVERIE_EMBEDDINGS=none` to turn embeddings off entirely.
+
+Each node stores two vectors: `embedding` (label, name and every text property) and `name_embedding` (label, name and aliases only), plus `embedding_model` and `embedded_at`. A semantic score is the better of the two, so a short query like `Ben Weeks` still matches a richly described `Benjamin Weeks`. None of these fields are ever returned by the tools.
 
 ### Setting up Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Unlike traditional approaches that embed complex logic in tools, this server pro
 - **Maximum flexibility**: The LLM can implement any strategy without tool limitations
 
 ### Search Behavior
-`search_memories` is hybrid: keyword hits (any word of the query as a substring of any property) rank first, then semantic matches above a similarity threshold. See **Search** below.
+`search_memories` is hybrid: keyword hits (any word of the query as a substring of any searchable content property) rank first, then semantic matches above a similarity threshold. See **Search** below.
 
 This approach makes the system more powerful and adaptable, as improvements in LLM capabilities directly translate to better memory management.
 
@@ -73,7 +73,7 @@ This approach makes the system more powerful and adaptable, as improvements in L
 
 `search_memories` now supports three modes:
 - `hybrid` (default): keyword hits score `1`, then semantic matches add close variants such as `Benjamin Weeks` for `Ben Weeks`
-- `keyword`: preserves today's substring-style word matching across all properties
+- `keyword`: any word of the query as a substring of any searchable content property (timestamps, `status` and embedding fields are never matched)
 - `semantic`: uses embeddings only when available, with graceful fallback to keyword behavior if embeddings are unavailable
 
 Use `similarity_threshold` (default `0.4`, clamped to `0..1`) to control how strict semantic matches are. Results include `_score` and `_match` on each returned `memory` object so callers can explain why a memory was returned.
@@ -144,7 +144,7 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 
 ## Prerequisites
 
-1. **Neo4j Database** (v4.4+ or v5.x)
+1. **Neo4j Database** 5.9 or newer (the `dream` tool uses `COUNT {}` and `IS :: STRING`); APOC for duplicate merging
    - Install Neo4j Community or Enterprise Edition
    - Download from [neo4j.com/download](https://neo4j.com/download/)
    - Or use Docker: `docker run -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/password neo4j`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@knowall-ai/reverie",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knowall-ai/reverie",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "0.6.0",
         "dotenv": "^17.2.0",
         "neo4j-driver": "^5.27.0",
@@ -35,6 +36,514 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.10.tgz",
+      "integrity": "sha512-SgS1D1bglQ94ceD4ZCL6eayUDy9uV1xuyk61OjgSxU5GJh7upqZCKII0JoTYMc6wWsg3JUgaPRX0ElQzXPk3Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -76,6 +585,63 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -108,7 +674,6 @@
       "version": "20.17.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.11.tgz",
       "integrity": "sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -167,6 +732,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -200,6 +772,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -216,6 +797,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -224,6 +839,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -245,6 +875,111 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/http-errors": {
@@ -301,12 +1036,57 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/neo4j-driver": {
       "version": "5.27.0",
@@ -336,6 +1116,87 @@
       "integrity": "sha512-TXZLNjtLrySRyBPBiRkQ/Ewmt4PQG0rm/Q2ZPNPqxbq1S0UVd53PQ2N6jxKiWlkrlPfrVRd2DyE8M7X9MDXxZw==",
       "license": "Apache-2.0"
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/raw-body": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
@@ -349,6 +1210,23 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/rxjs": {
@@ -386,11 +1264,94 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -408,6 +1369,22 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/toidentifier": {
@@ -469,6 +1446,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -487,7 +1476,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -518,6 +1506,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@knowall-ai/reverie",
-  "version": "0.3.0",
-  "description": "Reverie \u2014 graph memory that dreams. Graph-based memory system for AI agents. Store people, places, organizations as nodes. Build semantic relationships (KNOWS, WORKS_AT, CREATED). Word-tokenized search finds partial matches. Filter by date, traverse relationships, maintain temporal context. Simple tools, LLM handles complexity. 10 tools for complete memory management.",
+  "version": "0.4.0",
+  "description": "Reverie — graph memory that dreams. Graph-based memory system for AI agents. Store people, places, organizations as nodes. Build semantic relationships (KNOWS, WORKS_AT, CREATED). Hybrid keyword + semantic search finds partial matches and close variants. Filter by date, traverse relationships, maintain temporal context. Simple tools, LLM handles complexity. 13 tools for complete memory management.",
   "type": "module",
   "module": "./src/index.ts",
   "bin": {
@@ -15,9 +15,12 @@
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "prepare": "npm run build",
     "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js"
+    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
+    "test": "node tests/run-all-tests.js",
+    "test:unit": "node tests/test-embeddings-unit.js"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "0.6.0",
     "dotenv": "^17.2.0",
     "neo4j-driver": "^5.27.0",

--- a/src/cypher-guard.ts
+++ b/src/cypher-guard.ts
@@ -1,7 +1,8 @@
 /** Read-only guard for caller-supplied Cypher. Defence in depth: the query also runs in a READ transaction. */
 
 const WRITE_CLAUSE_RE = /\b(CREATE|MERGE|SET|DELETE|REMOVE|DROP|DETACH|FOREACH|LOAD\s+CSV)\b/i;
-const CALL_RE = /\bCALL\b\s*(\{|([A-Za-z_][\w.]*))/gi;
+const CALL_TOKEN_RE = /\bCALL\b/gi;
+const PROCEDURE_RE = /^\s*([A-Za-z_][\w.]*)/;
 
 /** Built-in procedures that only read. Anything else (APOC, db.create.*, dbms.*) is rejected. */
 export const READ_ONLY_PROCEDURES = new Set<string>([
@@ -17,20 +18,31 @@ export const READ_ONLY_PROCEDURES = new Set<string>([
   'db.index.fulltext.queryrelationships'
 ]);
 
+/** Remove line and block comments so nothing can hide between a keyword and what follows it. */
+export function stripComments(cypher: string): string {
+  return cypher.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
 /** Returns why the Cypher is not read-only, or null when it passes the guard. */
-export function readOnlyViolation(cypher: string): string | null {
+export function readOnlyViolation(rawCypher: string): string | null {
+  const cypher = stripComments(rawCypher);
+
   const writeClause = cypher.match(WRITE_CLAUSE_RE);
   if (writeClause) {
     return `${writeClause[1].toUpperCase()} is not allowed`;
   }
 
-  for (const match of cypher.matchAll(CALL_RE)) {
-    if (match[1] === '{') {
+  for (const match of cypher.matchAll(CALL_TOKEN_RE)) {
+    const rest = cypher.slice(match.index! + match[0].length);
+    if (/^\s*\{/.test(rest)) {
       return 'CALL subqueries are not allowed';
     }
-    const procedure = match[2].toLowerCase();
-    if (!READ_ONLY_PROCEDURES.has(procedure)) {
-      return `procedure ${match[2]} is not on the read-only allow-list`;
+    const procedure = rest.match(PROCEDURE_RE);
+    if (!procedure) {
+      return 'CALL could not be resolved to a procedure';
+    }
+    if (!READ_ONLY_PROCEDURES.has(procedure[1].toLowerCase())) {
+      return `procedure ${procedure[1]} is not on the read-only allow-list`;
     }
   }
 

--- a/src/cypher-guard.ts
+++ b/src/cypher-guard.ts
@@ -1,0 +1,38 @@
+/** Read-only guard for caller-supplied Cypher. Defence in depth: the query also runs in a READ transaction. */
+
+const WRITE_CLAUSE_RE = /\b(CREATE|MERGE|SET|DELETE|REMOVE|DROP|DETACH|FOREACH|LOAD\s+CSV)\b/i;
+const CALL_RE = /\bCALL\b\s*(\{|([A-Za-z_][\w.]*))/gi;
+
+/** Built-in procedures that only read. Anything else (APOC, db.create.*, dbms.*) is rejected. */
+export const READ_ONLY_PROCEDURES = new Set<string>([
+  'db.labels',
+  'db.relationshiptypes',
+  'db.propertykeys',
+  'db.schema.visualization',
+  'db.schema.nodetypeproperties',
+  'db.schema.reltypeproperties',
+  'db.index.vector.querynodes',
+  'db.index.vector.queryrelationships',
+  'db.index.fulltext.querynodes',
+  'db.index.fulltext.queryrelationships'
+]);
+
+/** Returns why the Cypher is not read-only, or null when it passes the guard. */
+export function readOnlyViolation(cypher: string): string | null {
+  const writeClause = cypher.match(WRITE_CLAUSE_RE);
+  if (writeClause) {
+    return `${writeClause[1].toUpperCase()} is not allowed`;
+  }
+
+  for (const match of cypher.matchAll(CALL_RE)) {
+    if (match[1] === '{') {
+      return 'CALL subqueries are not allowed';
+    }
+    const procedure = match[2].toLowerCase();
+    if (!READ_ONLY_PROCEDURES.has(procedure)) {
+      return `procedure ${match[2]} is not on the read-only allow-list`;
+    }
+  }
+
+  return null;
+}

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -38,15 +38,48 @@ function getModel(env: NodeJS.ProcessEnv, provider: Provider): string {
   return env.REVERIE_EMBEDDING_MODEL?.trim() || DEFAULT_MODELS[provider];
 }
 
-async function fetchJson(url: string, init: RequestInit): Promise<any> {
-  const response = await fetch(url, init);
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 120_000;
+let requestTimeoutMs = DEFAULT_TIMEOUT_MS;
 
-  if (!response.ok) {
-    const body = (await response.text()).slice(0, 200);
-    throw new Error(`Embedding request failed ${response.status}: ${body}`);
+/** REVERIE_EMBED_TIMEOUT_MS, whole milliseconds, clamped to 1s..120s. */
+function configuredTimeoutMs(env: NodeJS.ProcessEnv): number {
+  const raw = (env.REVERIE_EMBED_TIMEOUT_MS ?? '').trim();
+  const value = /^\d+$/.test(raw) ? Number(raw) : DEFAULT_TIMEOUT_MS;
+  return Math.min(Math.max(value, 1_000), MAX_TIMEOUT_MS);
+}
+
+/** Credentials only travel over TLS; plain http is allowed for loopback hosts (local proxies). */
+export function secureEndpoint(raw: string, name: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${name} is not a valid URL`);
   }
+  const loopback = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+    throw new Error(`${name} must use https (http is only accepted for localhost)`);
+  }
+  return url.toString().replace(/\/$/, '');
+}
 
-  return response.json();
+async function fetchJson(url: string, init: RequestInit): Promise<any> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+
+    if (!response.ok) {
+      const body = (await response.text()).slice(0, 200);
+      throw new Error(`Embedding request failed ${response.status}: ${body}`);
+    }
+
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function embedRemote(
@@ -83,6 +116,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
   }
 
   const model = getModel(env, provider);
+  requestTimeoutMs = configuredTimeoutMs(env);
 
   if (provider === 'local') {
     let extractorPromise: Promise<any> | null = null;
@@ -123,7 +157,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
       throw new Error('OPENAI_API_KEY is required for OpenAI embeddings');
     }
 
-    const baseUrl = env.OPENAI_BASE_URL?.trim() || 'https://api.openai.com/v1';
+    const baseUrl = secureEndpoint(env.OPENAI_BASE_URL?.trim() || 'https://api.openai.com/v1', 'OPENAI_BASE_URL');
     return {
       id: `${provider}/${model}`,
       async embed(texts: string[]): Promise<number[][]> {
@@ -145,14 +179,15 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
   }
 
   if (provider === 'azure') {
-    const endpoint = env.AZURE_OPENAI_ENDPOINT?.trim();
+    const rawEndpoint = env.AZURE_OPENAI_ENDPOINT?.trim();
     const apiKey = env.AZURE_OPENAI_API_KEY?.trim();
     const deployment = env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT?.trim();
     const apiVersion = env.AZURE_OPENAI_API_VERSION?.trim() || '2024-10-21';
 
-    if (!endpoint) {
+    if (!rawEndpoint) {
       throw new Error('AZURE_OPENAI_ENDPOINT is required for Azure embeddings');
     }
+    const endpoint = secureEndpoint(rawEndpoint, 'AZURE_OPENAI_ENDPOINT');
     if (!apiKey) {
       throw new Error('AZURE_OPENAI_API_KEY is required for Azure embeddings');
     }
@@ -165,7 +200,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
       async embed(texts: string[]): Promise<number[][]> {
         return embedRemote(texts, async (batch) => {
           const data = await fetchJson(
-            `${endpoint.replace(/\/$/, '')}/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`,
+            `${endpoint}/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`,
             {
               method: 'POST',
               headers: {

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -63,6 +63,14 @@ export function secureEndpoint(raw: string, name: string): string {
   return url.toString().replace(/\/$/, '');
 }
 
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
+
 /** Credentials never follow a redirect (a cross-origin or https→http hop would leak them); every request is bounded by timeoutMs. */
 async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Promise<any> {
   const controller = new AbortController();
@@ -91,10 +99,26 @@ async function embedRemote(
   for (let index = 0; index < texts.length; index += 64) {
     const batch = texts.slice(index, index + 64);
     const batchVectors = await doRequest(batch);
+    // Vectors are paired back to inputs by position, so a short batch would shift every later pair.
+    if (batchVectors.length !== batch.length) {
+      throw new Error(`Embedding provider returned ${batchVectors.length} vectors for ${batch.length} inputs`);
+    }
     vectors.push(...batchVectors);
   }
 
   return vectors;
+}
+
+/** OpenAI-style `{ data: [{ index, embedding }] }`: order by the declared index, not array position. */
+function vectorsFromData(data: unknown): number[][] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  const items = data as Array<{ index?: unknown; embedding?: unknown }>;
+  const ordered = items.every((item) => typeof item.index === 'number')
+    ? [...items].sort((a, b) => (a.index as number) - (b.index as number))
+    : items;
+  return ordered.map((item) => normalizeVector(item.embedding));
 }
 
 function normalizeVector(value: unknown): number[] {
@@ -129,13 +153,20 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
         }
 
         if (!extractorPromise) {
-          extractorPromise = (async () => {
+          // Loading may download the model; bound it, and forget a failed load so a later
+          // call can retry instead of falling back to keyword search until the process restarts.
+          const loading = (async () => {
             const transformers: any = await import('@huggingface/transformers');
             if (env.REVERIE_MODEL_CACHE?.trim()) {
               transformers.env.cacheDir = env.REVERIE_MODEL_CACHE.trim();
             }
             return transformers.pipeline('feature-extraction', model, { dtype: 'q8' });
           })();
+          extractorPromise = withTimeout(loading, timeoutMs, `local embedding model ${model} did not load within ${timeoutMs}ms`)
+            .catch((error) => {
+              extractorPromise = null;
+              throw error;
+            });
         }
 
         const extractor = await extractorPromise;
@@ -170,9 +201,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
             },
             body: JSON.stringify({ model, input: batch })
           }, timeoutMs);
-          return Array.isArray(data.data)
-            ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
-            : [];
+          return vectorsFromData(data.data);
         });
       }
     };
@@ -212,9 +241,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
             timeoutMs
           );
 
-          return Array.isArray(data.data)
-            ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
-            : [];
+          return vectorsFromData(data.data);
         });
       }
     };
@@ -260,9 +287,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
           body: JSON.stringify({ model, input: batch })
         }, timeoutMs);
 
-        return Array.isArray(data.data)
-          ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
-          : [];
+        return vectorsFromData(data.data);
       });
     }
   };

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -40,7 +40,6 @@ function getModel(env: NodeJS.ProcessEnv, provider: Provider): string {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 120_000;
-let requestTimeoutMs = DEFAULT_TIMEOUT_MS;
 
 /** REVERIE_EMBED_TIMEOUT_MS, whole milliseconds, clamped to 1s..120s. */
 function configuredTimeoutMs(env: NodeJS.ProcessEnv): number {
@@ -64,12 +63,13 @@ export function secureEndpoint(raw: string, name: string): string {
   return url.toString().replace(/\/$/, '');
 }
 
-async function fetchJson(url: string, init: RequestInit): Promise<any> {
+/** Credentials never follow a redirect (a cross-origin or https→http hop would leak them); every request is bounded by timeoutMs. */
+async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Promise<any> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal, redirect: 'error' });
 
     if (!response.ok) {
       const body = (await response.text()).slice(0, 200);
@@ -116,7 +116,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
   }
 
   const model = getModel(env, provider);
-  requestTimeoutMs = configuredTimeoutMs(env);
+  const timeoutMs = configuredTimeoutMs(env);
 
   if (provider === 'local') {
     let extractorPromise: Promise<any> | null = null;
@@ -169,7 +169,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
               'Content-Type': 'application/json'
             },
             body: JSON.stringify({ model, input: batch })
-          });
+          }, timeoutMs);
           return Array.isArray(data.data)
             ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
             : [];
@@ -208,7 +208,8 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
                 'Content-Type': 'application/json'
               },
               body: JSON.stringify({ model, input: batch })
-            }
+            },
+            timeoutMs
           );
 
           return Array.isArray(data.data)
@@ -220,18 +221,18 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
   }
 
   if (provider === 'ollama') {
-    const host = env.OLLAMA_HOST?.trim() || 'http://127.0.0.1:11434';
+    const host = secureEndpoint(env.OLLAMA_HOST?.trim() || 'http://127.0.0.1:11434', 'OLLAMA_HOST');
     return {
       id: `${provider}/${model}`,
       async embed(texts: string[]): Promise<number[][]> {
         return embedRemote(texts, async (batch) => {
-          const data = await fetchJson(`${host.replace(/\/$/, '')}/api/embed`, {
+          const data = await fetchJson(`${host}/api/embed`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json'
             },
             body: JSON.stringify({ model, input: batch })
-          });
+          }, timeoutMs);
 
           return Array.isArray(data.embeddings)
             ? data.embeddings.map((item: unknown) => normalizeVector(item))
@@ -257,7 +258,7 @@ export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder |
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({ model, input: batch })
-        });
+        }, timeoutMs);
 
         return Array.isArray(data.data)
           ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,0 +1,317 @@
+export interface Embedder {
+  readonly id: string;
+  readonly dims?: number;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export const EMBEDDING_FIELDS = ['embedding', 'name_embedding', 'embedding_model', 'embedded_at'] as const;
+
+/** Vectors stored on a node: `embedding` covers the full text, `name_embedding` only label, name and aliases. */
+export interface NodeEmbeddings {
+  embedding: number[];
+  name_embedding: number[];
+}
+
+const DEFAULT_MODELS = {
+  local: 'Xenova/all-MiniLM-L6-v2',
+  openai: 'text-embedding-3-small',
+  azure: 'text-embedding-3-small',
+  ollama: 'nomic-embed-text',
+  voyage: 'voyage-3-lite'
+} as const;
+
+type Provider = keyof typeof DEFAULT_MODELS;
+
+function getProvider(env: NodeJS.ProcessEnv): Provider | 'none' {
+  const raw = env.REVERIE_EMBEDDINGS?.trim().toLowerCase() ?? 'local';
+  if (raw === 'local' || raw === 'openai' || raw === 'azure' || raw === 'ollama' || raw === 'voyage') {
+    return raw;
+  }
+  if (raw === 'none') {
+    return 'none';
+  }
+  console.error(`Embeddings disabled: unknown provider "${env.REVERIE_EMBEDDINGS}"`);
+  return 'none';
+}
+
+function getModel(env: NodeJS.ProcessEnv, provider: Provider): string {
+  return env.REVERIE_EMBEDDING_MODEL?.trim() || DEFAULT_MODELS[provider];
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<any> {
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 200);
+    throw new Error(`Embedding request failed ${response.status}: ${body}`);
+  }
+
+  return response.json();
+}
+
+async function embedRemote(
+  texts: string[],
+  doRequest: (batch: string[]) => Promise<number[][]>
+): Promise<number[][]> {
+  const vectors: number[][] = [];
+
+  for (let index = 0; index < texts.length; index += 64) {
+    const batch = texts.slice(index, index + 64);
+    const batchVectors = await doRequest(batch);
+    vectors.push(...batchVectors);
+  }
+
+  return vectors;
+}
+
+function normalizeVector(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((item) => Number(item));
+}
+
+export function createEmbedder(env: NodeJS.ProcessEnv = process.env): Embedder | null {
+  const provider = getProvider(env);
+
+  if (provider === 'none') {
+    if ((env.REVERIE_EMBEDDINGS?.trim().toLowerCase() ?? '') === 'none') {
+      console.error('Embeddings disabled: provider set to none');
+    }
+    return null;
+  }
+
+  const model = getModel(env, provider);
+
+  if (provider === 'local') {
+    let extractorPromise: Promise<any> | null = null;
+
+    return {
+      id: `${provider}/${model}`,
+      async embed(texts: string[]): Promise<number[][]> {
+        if (texts.length === 0) {
+          return [];
+        }
+
+        if (!extractorPromise) {
+          extractorPromise = (async () => {
+            const transformers: any = await import('@huggingface/transformers');
+            if (env.REVERIE_MODEL_CACHE?.trim()) {
+              transformers.env.cacheDir = env.REVERIE_MODEL_CACHE.trim();
+            }
+            return transformers.pipeline('feature-extraction', model, { dtype: 'q8' });
+          })();
+        }
+
+        const extractor = await extractorPromise;
+        const output = await extractor(texts, { pooling: 'mean', normalize: true });
+        const vectors = Array.isArray(output) ? output : (output as { tolist?: () => unknown }).tolist?.();
+
+        if (!Array.isArray(vectors)) {
+          throw new Error('Local embedding pipeline returned an unexpected result');
+        }
+
+        return vectors.map((vector) => normalizeVector(vector));
+      }
+    };
+  }
+
+  if (provider === 'openai') {
+    const apiKey = env.OPENAI_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error('OPENAI_API_KEY is required for OpenAI embeddings');
+    }
+
+    const baseUrl = env.OPENAI_BASE_URL?.trim() || 'https://api.openai.com/v1';
+    return {
+      id: `${provider}/${model}`,
+      async embed(texts: string[]): Promise<number[][]> {
+        return embedRemote(texts, async (batch) => {
+          const data = await fetchJson(`${baseUrl}/embeddings`, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${apiKey}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ model, input: batch })
+          });
+          return Array.isArray(data.data)
+            ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
+            : [];
+        });
+      }
+    };
+  }
+
+  if (provider === 'azure') {
+    const endpoint = env.AZURE_OPENAI_ENDPOINT?.trim();
+    const apiKey = env.AZURE_OPENAI_API_KEY?.trim();
+    const deployment = env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT?.trim();
+    const apiVersion = env.AZURE_OPENAI_API_VERSION?.trim() || '2024-10-21';
+
+    if (!endpoint) {
+      throw new Error('AZURE_OPENAI_ENDPOINT is required for Azure embeddings');
+    }
+    if (!apiKey) {
+      throw new Error('AZURE_OPENAI_API_KEY is required for Azure embeddings');
+    }
+    if (!deployment) {
+      throw new Error('AZURE_OPENAI_EMBEDDING_DEPLOYMENT is required for Azure embeddings');
+    }
+
+    return {
+      id: `${provider}/${deployment}`,
+      async embed(texts: string[]): Promise<number[][]> {
+        return embedRemote(texts, async (batch) => {
+          const data = await fetchJson(
+            `${endpoint.replace(/\/$/, '')}/openai/deployments/${deployment}/embeddings?api-version=${apiVersion}`,
+            {
+              method: 'POST',
+              headers: {
+                'api-key': apiKey,
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({ model, input: batch })
+            }
+          );
+
+          return Array.isArray(data.data)
+            ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
+            : [];
+        });
+      }
+    };
+  }
+
+  if (provider === 'ollama') {
+    const host = env.OLLAMA_HOST?.trim() || 'http://127.0.0.1:11434';
+    return {
+      id: `${provider}/${model}`,
+      async embed(texts: string[]): Promise<number[][]> {
+        return embedRemote(texts, async (batch) => {
+          const data = await fetchJson(`${host.replace(/\/$/, '')}/api/embed`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ model, input: batch })
+          });
+
+          return Array.isArray(data.embeddings)
+            ? data.embeddings.map((item: unknown) => normalizeVector(item))
+            : [];
+        });
+      }
+    };
+  }
+
+  const apiKey = env.VOYAGE_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('VOYAGE_API_KEY is required for Voyage embeddings');
+  }
+
+  return {
+    id: `${provider}/${model}`,
+    async embed(texts: string[]): Promise<number[][]> {
+      return embedRemote(texts, async (batch) => {
+        const data = await fetchJson('https://api.voyageai.com/v1/embeddings', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ model, input: batch })
+        });
+
+        return Array.isArray(data.data)
+          ? data.data.map((item: { embedding: unknown }) => normalizeVector(item.embedding))
+          : [];
+      });
+    }
+  };
+}
+
+export function embeddingText(label: string, props: Record<string, unknown>): string {
+  const skipKeys = new Set<string>([...EMBEDDING_FIELDS, 'created_at', 'updated_at']);
+  const lines: string[] = [`${label}: ${String(props.name ?? '')}`.trim()];
+
+  for (const [key, value] of Object.entries(props)) {
+    if (key === 'name' || skipKeys.has(key) || key.endsWith('_id') || key.endsWith('Id')) {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      lines.push(`${key}: ${value}`);
+      continue;
+    }
+
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string' || typeof item === 'number')) {
+      lines.push(`${key}: ${value.join(', ')}`);
+    }
+  }
+
+  return lines.join('\n').slice(0, 1000);
+}
+
+/** Label, name and aliases only. Kept separate because descriptive text dilutes name similarity badly. */
+export function nameText(label: string, props: Record<string, unknown>): string {
+  const lines = [`${label}: ${String(props.name ?? '')}`.trim()];
+  const aliases = props.aliases;
+  if (Array.isArray(aliases) && aliases.length > 0) {
+    lines.push(`aliases: ${aliases.map((alias) => String(alias)).join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+/** Embed a batch of nodes, two texts each, and pair the vectors back up per node. */
+export async function embedNodes(
+  embedder: Embedder,
+  nodes: Array<{ label: string; props: Record<string, unknown> }>
+): Promise<NodeEmbeddings[]> {
+  const texts = nodes.flatMap((node) => [embeddingText(node.label, node.props), nameText(node.label, node.props)]);
+  const vectors = await embedder.embed(texts);
+  return nodes.map((_, index) => ({
+    embedding: vectors[index * 2] ?? [],
+    name_embedding: vectors[index * 2 + 1] ?? []
+  }));
+}
+
+export function cosine(a: number[], b: number[]): number {
+  if (a.length === 0 || a.length !== b.length) {
+    return 0;
+  }
+
+  let dot = 0;
+  let aNorm = 0;
+  let bNorm = 0;
+
+  for (let index = 0; index < a.length; index += 1) {
+    dot += a[index] * b[index];
+    aNorm += a[index] * a[index];
+    bNorm += b[index] * b[index];
+  }
+
+  if (aNorm === 0 || bNorm === 0) {
+    return 0;
+  }
+
+  return dot / (Math.sqrt(aNorm) * Math.sqrt(bNorm));
+}
+
+export function scrub<T>(value: T): T {
+  const blocked = new Set<string>(EMBEDDING_FIELDS);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrub(item)) as T;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !blocked.has(key))
+      .map(([key, item]) => [key, scrub(item)]);
+    return Object.fromEntries(entries) as T;
+  }
+
+  return value;
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -466,9 +466,14 @@ export async function handleToolCall(
              AND NOT (n)--()
            RETURN count(n) AS count`
         );
+        // Simulate only what would actually merge: the survivor plus the merged ids, never the skipped ones.
         const mergedGroups = duplicateReport
           .filter((report) => report.merged.length > 0)
-          .map((report) => duplicates.find((group) => group[0].id === report.keep) ?? []);
+          .map((report) => {
+            const group = duplicates.find((candidate) => candidate[0].id === report.keep) ?? [];
+            const retained = new Set([report.keep, ...report.merged]);
+            return group.filter((node) => retained.has(node.id));
+          });
         const orphans = dryRun
           ? simulateOrphansAfterMerge(currentOrphanRow?.count ?? 0, mergedGroups)
           : currentOrphanRow?.count ?? 0;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,6 +2,7 @@ import { CallToolResult, ErrorCode, McpError } from '@modelcontextprotocol/sdk/t
 import neo4j from 'neo4j-driver';
 import { Embedder, embedNodes, scrub } from '../embeddings.js';
 import { Neo4jClient } from '../neo4j-client.js';
+import { bloatHint, contentKeys, factLikeKeys, maxProperties } from '../hygiene.js';
 import { Candidate, Ranked, SearchMode, rank } from '../search.js';
 import {
   isCreateConnectionArgs,
@@ -174,6 +175,14 @@ export async function handleToolCall(
           ? result.memory._labels[0]
           : 'Memory';
         await embedNodeIfPossible(neo4jClient, embedder, result?.memory, label, 'update_memory');
+
+        if (result?.memory) {
+          const count = contentKeys(result.memory).length;
+          const limit = maxProperties();
+          if (count > limit) {
+            result.memory._hint = bloatHint(String(result.memory.name ?? args.nodeId), count, limit);
+          }
+        }
         return jsonResult(result);
       }
 
@@ -418,12 +427,18 @@ export async function handleToolCall(
           ? simulateOrphansAfterMerge(currentOrphanRow?.count ?? 0, duplicates)
           : currentOrphanRow?.count ?? 0;
 
+        const bloated = await findBloatedNodes(neo4jClient, maxProperties());
+        if (bloated.length > 0) {
+          notes.push(`${bloated.length} node(s) exceed ${maxProperties()} properties; split their fact-like keys into their own memories (see bloated)`);
+        }
+
         return jsonResult({
           dry_run: dryRun,
           relabelled,
           merged,
           reembedded,
           orphans,
+          bloated,
           apoc_available: apocAvailable,
           notes
         });
@@ -599,6 +614,36 @@ async function fetchMemories(
   }
 
   return neo4jClient.executeQuery(finalQuery, { memoryIds });
+}
+
+interface BloatedNode {
+  id: number;
+  label: string;
+  name: string;
+  properties: number;
+  fact_like_keys: string[];
+}
+
+/** Nodes carrying more than `limit` real properties, worst first, with the keys that should become their own memories. */
+async function findBloatedNodes(neo4jClient: Neo4jClient, limit: number): Promise<BloatedNode[]> {
+  const rows = await neo4jClient.executeQuery<{ id: number; label: string; props: Record<string, unknown> }>(
+    `MATCH (n)
+     WHERE coalesce(n.status, '') <> 'archived' AND size(keys(n)) > $limit
+     RETURN id(n) AS id, labels(n)[0] AS label, properties(n) AS props`,
+    { limit: neo4j.int(limit) }
+  );
+
+  return rows
+    .map((row) => ({
+      id: row.id,
+      label: row.label || 'Memory',
+      name: String(row.props.name ?? row.id),
+      properties: contentKeys(row.props).length,
+      fact_like_keys: factLikeKeys(row.props).slice(0, 25)
+    }))
+    .filter((node) => node.properties > limit)
+    .sort((left, right) => right.properties - left.properties)
+    .slice(0, 20);
 }
 
 function jsonResult(value: unknown): CallToolResult {

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,21 +1,55 @@
 import { CallToolResult, ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import neo4j from 'neo4j-driver';
+import { Embedder, embedNodes, scrub } from '../embeddings.js';
 import { Neo4jClient } from '../neo4j-client.js';
+import { Candidate, Ranked, SearchMode, rank } from '../search.js';
 import {
-  isCreateMemoryArgs,
-  isSearchMemoriesArgs,
   isCreateConnectionArgs,
-  isUpdateMemoryArgs,
-  isUpdateConnectionArgs,
-  isDeleteMemoryArgs,
+  isCreateMemoryArgs,
   isDeleteConnectionArgs,
-  isListMemoryLabelsArgs
+  isDeleteMemoryArgs,
+  isDreamArgs,
+  isListMemoryLabelsArgs,
+  isMemoryStatsArgs,
+  isQueryMemoriesArgs,
+  isSearchMemoriesArgs,
+  isUpdateConnectionArgs,
+  isUpdateMemoryArgs
 } from '../types.js';
-import { isGetGuidanceArgs, getGuidanceContent } from '../tools/guidance-tool.js';
+import { getGuidanceContent, isGetGuidanceArgs } from '../tools/guidance-tool.js';
+
+interface SearchCandidate extends Candidate {
+  label: string;
+}
+
+interface DuplicateNodeRow {
+  id: number;
+  label: string;
+  name: string;
+  created_at?: string;
+  rel_count: number;
+}
+
+interface GroupedDuplicateNode extends DuplicateNodeRow {
+  effectiveLabel: string;
+}
+
+// Blocks write clauses, subqueries and every procedure except the read-only db.* / dbms.* ones (APOC can write).
+const EMBED_NODE_CYPHER = `
+  MATCH (n)
+  WHERE id(n) = $id
+  SET n.embedding = $embedding,
+      n.name_embedding = $nameEmbedding,
+      n.embedding_model = $model,
+      n.embedded_at = $embeddedAt`;
+
+const READ_ONLY_CYPHER_RE = /\b(CREATE|MERGE|SET|DELETE|REMOVE|DROP|DETACH|LOAD\s+CSV)\b|\bCALL\b(?!\s+(db|dbms)\.)/i;
 
 export async function handleToolCall(
   name: string,
   args: unknown,
-  neo4j: Neo4jClient
+  neo4jClient: Neo4jClient,
+  embedder: Embedder | null
 ): Promise<CallToolResult> {
   try {
     switch (name) {
@@ -23,313 +57,389 @@ export async function handleToolCall(
         if (!isSearchMemoriesArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid search_memories arguments');
         }
-        
+
         const depth = args.depth ?? 1;
         const limit = Math.min(args.limit ?? 10, 200);
-        
+        const query = args.query ?? '';
+        const requestedMode = args.search_mode ?? 'hybrid';
+        const similarityThreshold = clamp(args.similarity_threshold ?? 0.4, 0, 1);
         let orderBy = 'memory.created_at DESC';
+        let hasCustomOrder = false;
         if (args.order_by) {
           const orderMatch = args.order_by.match(/^(memory\.|n\.)?([a-zA-Z_]+)\s+(ASC|DESC)$/i);
           if (orderMatch) {
-            const property = orderMatch[2];
-            const direction = orderMatch[3].toUpperCase();
-            orderBy = `memory.${property} ${direction}`;
+            orderBy = `memory.${orderMatch[2]} ${orderMatch[3].toUpperCase()}`;
+            hasCustomOrder = true;
           }
         }
-        
-        const params: Record<string, any> = {};
-        if (args.query) params.query = args.query;
-        if (args.label) params.label = args.label;
-        if (args.since_date) params.since_date = args.since_date;
-        
-        // Try a different approach: execute simple queries and handle complexity in JavaScript
-        const allMemoryIds = new Set<number>();
-        
-        try {
-          // First, get all memories that match the label and date filters (if any)
-          let baseQuery = `MATCH (memory)`;
-          const conditions = [];
-          
-          if (args.label) {
-            conditions.push(`labels(memory)[0] = $label`);
+
+        let baseQuery = 'MATCH (memory)';
+        const conditions: string[] = [];
+        const queryParams: Record<string, any> = {};
+
+        if (args.label) {
+          conditions.push('toLower(labels(memory)[0]) = toLower($label)');
+          queryParams.label = args.label;
+        }
+
+        if (args.since_date) {
+          conditions.push('memory.created_at >= $since_date');
+          queryParams.since_date = args.since_date;
+        }
+
+        if (conditions.length > 0) {
+          baseQuery += ` WHERE ${conditions.join(' AND ')}`;
+        }
+
+        baseQuery += ' RETURN id(memory) AS id, labels(memory)[0] AS label, properties(memory) AS props';
+        const rawCandidates = await neo4jClient.executeQuery<SearchCandidate>(baseQuery, queryParams);
+        const candidates = rawCandidates.map((candidate) => ({
+          id: candidate.id,
+          label: candidate.label || 'Memory',
+          props: candidate.props || {}
+        }));
+
+        const ranking = await rankCandidates(neo4jClient, candidates, query, requestedMode, similarityThreshold, embedder);
+        const topRanked = ranking.slice(0, limit);
+        const rankedIds = topRanked.map((item) => item.id);
+
+        if (rankedIds.length === 0) {
+          return jsonResult([]);
+        }
+
+        const result = await fetchMemories(neo4jClient, rankedIds, depth, orderBy, limit);
+        const scoring = new Map<number, { score: number; match: Ranked['match'] }>(
+          topRanked.map((item) => [item.id, { score: Number(item.score.toFixed(2)), match: item.match }])
+        );
+
+        for (const row of result) {
+          const memoryId = row?.memory?._id;
+          if (typeof memoryId !== 'number') {
+            continue;
           }
-          
-          if (args.since_date) {
-            conditions.push(`memory.created_at >= $since_date`);
-          }
-          
-          if (conditions.length > 0) {
-            baseQuery += ` WHERE ` + conditions.join(' AND ');
-          }
-          
-          baseQuery += ` RETURN id(memory) as id, properties(memory) as props`;
-          
-          const queryParams: Record<string, any> = {};
-          if (args.label) queryParams.label = args.label;
-          if (args.since_date) queryParams.since_date = args.since_date;
-          
-          const allMemories = await neo4j.executeQuery(baseQuery, queryParams);
-          
-          // Filter in JavaScript
-          for (const record of allMemories) {
-            const props = record.props;
-            
-            // If query is empty, include all memories (they already match label/date filters)
-            if (!args.query || args.query.trim() === '') {
-              allMemoryIds.add(record.id);
-              continue;
-            }
-            
-            // Split query into words for more flexible matching
-            const queryWords = args.query.toLowerCase().trim().split(/\s+/);
-            let found = false;
-            
-            // Search through all properties
-            for (const [key, value] of Object.entries(props)) {
-              if (value === null || value === undefined) continue;
-              
-              const valueStr = Array.isArray(value) 
-                ? value.map(v => v?.toString() || '').join(' ').toLowerCase()
-                : value.toString().toLowerCase();
-              
-              // Check if ANY query word is found in this property
-              for (const word of queryWords) {
-                if (valueStr.includes(word)) {
-                  found = true;
-                  break;
-                }
-              }
-              
-              if (found) {
-                allMemoryIds.add(record.id);
-                break;
-              }
-            }
-          }
-        } catch (error) {
-          console.error('Error in search:', error);
-          // Fallback to a simpler query if the above fails
-          const conditions = [];
-          
-          if (args.query && args.query.trim() !== '') {
-            conditions.push('(memory.name CONTAINS $query OR memory.context CONTAINS $query OR memory.description CONTAINS $query)');
-          }
-          
-          if (args.label) {
-            conditions.push('labels(memory)[0] = $label');
-          }
-          
-          if (args.since_date) {
-            conditions.push('memory.created_at >= $since_date');
-          }
-          
-          let fallbackQuery = `MATCH (memory)`;
-          if (conditions.length > 0) {
-            fallbackQuery += ` WHERE ${conditions.join(' AND ')}`;
-          }
-          fallbackQuery += ` RETURN collect(DISTINCT id(memory)) as memoryIds`;
-          
-          const fallbackParams: Record<string, any> = {};
-          if (args.query) fallbackParams.query = args.query;
-          if (args.label) fallbackParams.label = args.label;
-          if (args.since_date) fallbackParams.since_date = args.since_date;
-          
-          const fallbackResults = await neo4j.executeQuery(fallbackQuery, fallbackParams);
-          if (fallbackResults.length > 0 && fallbackResults[0].memoryIds) {
-            fallbackResults[0].memoryIds.forEach((id: number) => allMemoryIds.add(id));
+
+          const meta = scoring.get(memoryId);
+          if (meta) {
+            row.memory._score = meta.score;
+            row.memory._match = meta.match;
           }
         }
-        
-        
-        if (allMemoryIds.size === 0) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify([], null, 2),
-              },
-            ],
-          };
-        }
-        
-        // Query 3: Fetch the actual memories with connections
-        let finalQuery = `
-          MATCH (memory)
-          WHERE id(memory) IN $memoryIds
-        `;
-        
-        if (depth > 0) {
-          finalQuery += `
-            OPTIONAL MATCH path = (memory)-[*1..${depth}]-(related)
-            RETURN memory, collect(DISTINCT {
-              memory: related,
-              relationship: relationships(path)[0],
-              distance: length(path)
-            }) as connections
-            ORDER BY ${orderBy}
-            LIMIT ${limit}
-          `;
-        } else {
-          finalQuery += ` RETURN memory, [] as connections
-            ORDER BY ${orderBy}
-            LIMIT ${limit}`;
-        }
-        
-        const result = await neo4j.executeQuery(finalQuery, { memoryIds: Array.from(allMemoryIds) });
-        
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const orderedResult = hasCustomOrder
+          ? result
+          : rankedIds
+              .map((id) => result.find((row) => row?.memory?._id === id))
+              .filter((row): row is Record<string, any> => Boolean(row));
+
+        return jsonResult(orderedResult);
       }
 
       case 'create_memory': {
         if (!isCreateMemoryArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid create_memory arguments');
         }
-        
-        // Add created_at timestamp if not provided
+
         const properties = {
           ...args.properties,
           created_at: args.properties.created_at || new Date().toISOString()
         };
-        
-        const result = await neo4j.createNode(args.label, properties);
-        
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const result = await neo4jClient.createNode(args.label, properties);
+        await embedNodeIfPossible(neo4jClient, embedder, result?.memory, args.label, 'create_memory');
+        return jsonResult(result);
       }
 
       case 'create_connection': {
         if (!isCreateConnectionArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid create_connection arguments');
         }
-        
-        const result = await neo4j.createRelationship(
+
+        const result = await neo4jClient.createRelationship(
           args.fromMemoryId,
           args.toMemoryId,
           args.type,
           args.properties || { created_at: new Date().toISOString() }
         );
-        
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        return jsonResult(result);
       }
 
       case 'update_memory': {
         if (!isUpdateMemoryArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid update_memory arguments');
         }
-        const result = await neo4j.updateNode(args.nodeId, args.properties);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const result = await neo4jClient.updateNode(args.nodeId, args.properties);
+        const label = Array.isArray(result?.memory?._labels) && typeof result.memory._labels[0] === 'string'
+          ? result.memory._labels[0]
+          : 'Memory';
+        await embedNodeIfPossible(neo4jClient, embedder, result?.memory, label, 'update_memory');
+        return jsonResult(result);
       }
 
       case 'update_connection': {
         if (!isUpdateConnectionArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid update_connection arguments');
         }
-        const result = await neo4j.updateRelationship(args.fromMemoryId, args.toMemoryId, args.type, args.properties);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const result = await neo4jClient.updateRelationship(args.fromMemoryId, args.toMemoryId, args.type, args.properties);
+        return jsonResult(result);
       }
 
       case 'delete_memory': {
         if (!isDeleteMemoryArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid delete_memory arguments');
         }
-        const result = await neo4j.deleteNode(args.nodeId);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const result = await neo4jClient.deleteNode(args.nodeId);
+        return jsonResult(result);
       }
 
       case 'delete_connection': {
         if (!isDeleteConnectionArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid delete_connection arguments');
         }
-        const result = await neo4j.deleteRelationship(args.fromMemoryId, args.toMemoryId, args.type);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const result = await neo4jClient.deleteRelationship(args.fromMemoryId, args.toMemoryId, args.type);
+        return jsonResult(result);
       }
 
       case 'list_memory_labels': {
         if (!isListMemoryLabelsArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid list_memory_labels arguments');
         }
-        
+
         const query = `
           MATCH (memory)
-          WITH labels(memory) as nodeLabels
-          UNWIND nodeLabels as label
-          WITH label, count(*) as count
+          WITH labels(memory) AS nodeLabels
+          UNWIND nodeLabels AS label
+          WITH label, count(*) AS count
           ORDER BY count DESC, label
-          RETURN collect({label: label, count: count}) as labels, sum(count) as totalMemories
+          RETURN collect({label: label, count: count}) AS labels, sum(count) AS totalMemories
         `;
-        
-        const result = await neo4j.executeQuery(query, {});
-        
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+
+        const result = await neo4jClient.executeQuery(query, {});
+        return jsonResult(result);
+      }
+
+      case 'query_memories': {
+        if (!isQueryMemoriesArgs(args)) {
+          throw new McpError(ErrorCode.InvalidParams, 'Invalid query_memories arguments');
+        }
+
+        if (READ_ONLY_CYPHER_RE.test(args.cypher)) {
+          throw new McpError(ErrorCode.InvalidParams, 'query_memories only supports read-only Cypher');
+        }
+
+        const result = await neo4jClient.executeQuery(args.cypher, args.params ?? {});
+        return jsonResult(result.slice(0, 200));
+      }
+
+      case 'memory_stats': {
+        if (!isMemoryStatsArgs(args)) {
+          throw new McpError(ErrorCode.InvalidParams, 'Invalid memory_stats arguments');
+        }
+
+        const [nodeRow] = await neo4jClient.executeQuery<{ count: number }>(
+          `MATCH (n)
+           WHERE coalesce(n.status, '') <> 'archived'
+           RETURN count(n) AS count`
+        );
+        const [relationshipRow] = await neo4jClient.executeQuery<{ count: number }>(
+          'MATCH ()-[r]->() RETURN count(r) AS count'
+        );
+        const labelRows = await neo4jClient.executeQuery<{ label: string; count: number }>(
+          `MATCH (n)
+           WHERE coalesce(n.status, '') <> 'archived'
+           UNWIND labels(n) AS label
+           RETURN label, count(*) AS count
+           ORDER BY label`
+        );
+        const relationshipTypeRows = await neo4jClient.executeQuery<{ type: string; count: number }>(
+          'MATCH ()-[r]->() RETURN type(r) AS type, count(r) AS count ORDER BY type'
+        );
+        const [orphanRow] = await neo4jClient.executeQuery<{ count: number }>(
+          `MATCH (n)
+           WHERE coalesce(n.status, '') <> 'archived'
+             AND NOT (n)--()
+           RETURN count(n) AS count`
+        );
+
+        let embedded = 0;
+        let embedderId: string | null = null;
+        if (embedder) {
+          embedderId = embedder.id;
+          const [embeddedRow] = await neo4jClient.executeQuery<{ count: number }>(
+            `MATCH (n)
+             WHERE coalesce(n.status, '') <> 'archived'
+               AND n.embedding_model = $model
+             RETURN count(n) AS count`,
+            { model: embedder.id }
+          );
+          embedded = embeddedRow?.count ?? 0;
+        }
+
+        return jsonResult({
+          nodes: nodeRow?.count ?? 0,
+          relationships: relationshipRow?.count ?? 0,
+          labels: Object.fromEntries(labelRows.map((row) => [row.label, row.count])),
+          relationship_types: Object.fromEntries(relationshipTypeRows.map((row) => [row.type, row.count])),
+          embedded,
+          embedder: embedderId,
+          orphans: orphanRow?.count ?? 0
+        });
+      }
+
+      case 'dream': {
+        if (!isDreamArgs(args)) {
+          throw new McpError(ErrorCode.InvalidParams, 'Invalid dream arguments');
+        }
+
+        const dryRun = args.dry_run ?? false;
+        const notes: string[] = [];
+
+        const labelRows = await neo4jClient.executeQuery<{ label: string }>('CALL db.labels() YIELD label RETURN label ORDER BY label');
+        let relabelled = 0;
+
+        for (const row of labelRows) {
+          const sourceLabel = row.label;
+          if (!isAllLowercase(sourceLabel)) {
+            continue;
+          }
+
+          const targetLabel = capitalizeLabel(sourceLabel);
+          if (targetLabel === sourceLabel) {
+            continue;
+          }
+
+          const escapedSource = escapeIdentifier(sourceLabel);
+          const escapedTarget = escapeIdentifier(targetLabel);
+
+          if (dryRun) {
+            const [countRow] = await neo4jClient.executeQuery<{ count: number }>(
+              `MATCH (n:\`${escapedSource}\`) RETURN count(n) AS count`
+            );
+            relabelled += countRow?.count ?? 0;
+          } else {
+            const [countRow] = await neo4jClient.executeQuery<{ count: number }>(
+              `MATCH (n:\`${escapedSource}\`)
+               REMOVE n:\`${escapedSource}\`
+               SET n:\`${escapedTarget}\`
+               RETURN count(n) AS count`
+            );
+            relabelled += countRow?.count ?? 0;
+          }
+        }
+
+        const duplicateRows = await neo4jClient.executeQuery<DuplicateNodeRow>(
+          `MATCH (n)
+           WHERE coalesce(n.status, '') <> 'archived' AND n.name IS NOT NULL
+           RETURN id(n) AS id,
+                  labels(n)[0] AS label,
+                  n.name AS name,
+                  n.created_at AS created_at,
+                  COUNT { (n)--() } AS rel_count
+           ORDER BY labels(n)[0], toLower(n.name), n.created_at, id(n)`
+        );
+        const duplicates = groupDuplicates(duplicateRows);
+
+        let apocAvailable = true;
+        try {
+          await neo4jClient.executeQuery('RETURN apoc.version() AS v');
+        } catch (error) {
+          apocAvailable = false;
+        }
+
+        let merged = 0;
+        if (!apocAvailable) {
+          if (duplicates.length > 0) {
+            notes.push(`APOC unavailable; duplicate names found: ${duplicates.map((group) => `${group[0].effectiveLabel}/${group[0].name}`).join(', ')}`);
+          }
+        } else {
+          for (const group of duplicates) {
+            const [keep, ...rest] = group;
+            merged += rest.length;
+
+            if (dryRun) {
+              continue;
+            }
+
+            for (const duplicate of rest) {
+              await neo4jClient.executeQuery(
+                `MATCH (keep) WHERE id(keep) = $keepId
+                 MATCH (dup) WHERE id(dup) = $dupId
+                 CALL apoc.refactor.mergeNodes([keep, dup], {properties: 'discard', mergeRels: true})
+                 YIELD node
+                 RETURN count(node) AS count`,
+                {
+                  keepId: neo4j.int(keep.id),
+                  dupId: neo4j.int(duplicate.id)
+                }
+              );
+            }
+          }
+        }
+
+        let reembedded = 0;
+        if (embedder) {
+          const nodesToEmbed = await neo4jClient.executeQuery<SearchCandidate>(
+            `MATCH (n)
+             WHERE n.embedding_model IS NULL OR n.embedding_model <> $model OR n.name_embedding IS NULL
+             RETURN id(n) AS id, labels(n)[0] AS label, properties(n) AS props
+             ORDER BY id(n)`,
+            { model: embedder.id }
+          );
+
+          if (dryRun) {
+            reembedded = nodesToEmbed.length;
+          } else if (nodesToEmbed.length > 0) {
+            try {
+              for (let index = 0; index < nodesToEmbed.length; index += 50) {
+                const batch = nodesToEmbed.slice(index, index + 50).map((candidate) => ({
+                  id: candidate.id,
+                  label: candidate.label || 'Memory',
+                  props: candidate.props || {}
+                }));
+                reembedded += await persistCandidateEmbeddings(neo4jClient, embedder, batch);
+              }
+            } catch (error) {
+              console.error('Embedding unavailable for dream:', error);
+            }
+          }
+        }
+
+        const [currentOrphanRow] = await neo4jClient.executeQuery<{ count: number }>(
+          `MATCH (n)
+           WHERE coalesce(n.status, '') <> 'archived'
+             AND NOT (n)--()
+           RETURN count(n) AS count`
+        );
+        const orphans = dryRun
+          ? simulateOrphansAfterMerge(currentOrphanRow?.count ?? 0, duplicates)
+          : currentOrphanRow?.count ?? 0;
+
+        return jsonResult({
+          dry_run: dryRun,
+          relabelled,
+          merged,
+          reembedded,
+          orphans,
+          apoc_available: apocAvailable,
+          notes
+        });
       }
 
       case 'get_guidance': {
         if (!isGetGuidanceArgs(args)) {
           throw new McpError(ErrorCode.InvalidParams, 'Invalid get_guidance arguments');
         }
-        
-        const content = getGuidanceContent(args.topic);
-        
+
+        const topic = typeof args === 'object' && args !== null ? (args as { topic?: string }).topic : undefined;
         return {
           content: [
             {
               type: 'text',
-              text: content,
+              text: getGuidanceContent(topic),
             },
           ],
         };
@@ -350,4 +460,234 @@ export async function handleToolCall(
       isError: true,
     };
   }
+}
+
+async function rankCandidates(
+  neo4jClient: Neo4jClient,
+  candidates: SearchCandidate[],
+  query: string,
+  requestedMode: SearchMode,
+  threshold: number,
+  embedder: Embedder | null
+): Promise<Ranked[]> {
+  const trimmedQuery = query.trim();
+  let effectiveMode = requestedMode;
+  let queryEmbedding: number[] | undefined;
+
+  if (trimmedQuery && requestedMode !== 'keyword') {
+    if (!embedder) {
+      effectiveMode = 'keyword';
+    } else {
+      try {
+        const lazyBatch = getLazyEmbedBatchSize();
+        const candidatesToEmbed = candidates.filter((candidate) => needsEmbedding(candidate.props, embedder.id)).slice(0, lazyBatch);
+
+        if (candidatesToEmbed.length > 0) {
+          await persistCandidateEmbeddings(neo4jClient, embedder, candidatesToEmbed);
+        }
+
+        [queryEmbedding] = await embedder.embed([trimmedQuery]);
+      } catch (error) {
+        console.error('Embedding unavailable for search_memories:', error);
+        effectiveMode = 'keyword';
+        queryEmbedding = undefined;
+      }
+    }
+  }
+
+  return rank(candidates, {
+    query,
+    mode: effectiveMode,
+    queryEmbedding,
+    threshold,
+    modelId: embedder?.id
+  });
+}
+
+async function persistCandidateEmbeddings(
+  neo4jClient: Neo4jClient,
+  embedder: Embedder,
+  candidates: SearchCandidate[]
+): Promise<number> {
+  const vectors = await embedNodes(embedder, candidates);
+  const embeddedAt = new Date().toISOString();
+  let persisted = 0;
+
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index];
+    const { embedding, name_embedding } = vectors[index];
+    if (embedding.length === 0) {
+      continue;
+    }
+
+    await neo4jClient.executeQuery(EMBED_NODE_CYPHER, {
+      id: neo4j.int(candidate.id),
+      embedding,
+      nameEmbedding: name_embedding,
+      model: embedder.id,
+      embeddedAt
+    });
+
+    Object.assign(candidate.props, { embedding, name_embedding, embedding_model: embedder.id, embedded_at: embeddedAt });
+    persisted += 1;
+  }
+
+  return persisted;
+}
+
+async function embedNodeIfPossible(
+  neo4jClient: Neo4jClient,
+  embedder: Embedder | null,
+  memory: Record<string, any> | undefined,
+  label: string,
+  toolName: string
+): Promise<void> {
+  if (!embedder || !memory || typeof memory._id !== 'number') {
+    return;
+  }
+
+  try {
+    const [{ embedding, name_embedding }] = await embedNodes(embedder, [{ label, props: toNodeProperties(memory) }]);
+    if (embedding.length === 0) {
+      return;
+    }
+
+    const embeddedAt = new Date().toISOString();
+    await neo4jClient.executeQuery(EMBED_NODE_CYPHER, {
+      id: neo4j.int(memory._id),
+      embedding,
+      nameEmbedding: name_embedding,
+      model: embedder.id,
+      embeddedAt
+    });
+
+    Object.assign(memory, { embedding, name_embedding, embedding_model: embedder.id, embedded_at: embeddedAt });
+  } catch (error) {
+    console.error(`Embedding unavailable for ${toolName}:`, error);
+  }
+}
+
+async function fetchMemories(
+  neo4jClient: Neo4jClient,
+  memoryIds: number[],
+  depth: number,
+  orderBy: string,
+  limit: number
+): Promise<Record<string, any>[]> {
+  let finalQuery = `
+    MATCH (memory)
+    WHERE id(memory) IN $memoryIds
+  `;
+
+  if (depth > 0) {
+    finalQuery += `
+      OPTIONAL MATCH path = (memory)-[*1..${depth}]-(related)
+      RETURN memory, collect(DISTINCT {
+        memory: related,
+        relationship: relationships(path)[0],
+        distance: length(path)
+      }) AS connections
+      ORDER BY ${orderBy}
+      LIMIT ${limit}
+    `;
+  } else {
+    finalQuery += `
+      RETURN memory, [] AS connections
+      ORDER BY ${orderBy}
+      LIMIT ${limit}
+    `;
+  }
+
+  return neo4jClient.executeQuery(finalQuery, { memoryIds });
+}
+
+function jsonResult(value: unknown): CallToolResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(scrub(value), null, 2),
+      },
+    ],
+  };
+}
+
+/** Stale when embedded by another model/provider, or before the name vector was introduced. */
+function needsEmbedding(props: Record<string, any>, modelId: string): boolean {
+  return props.embedding_model !== modelId || !Array.isArray(props.name_embedding);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getLazyEmbedBatchSize(): number {
+  const raw = Number.parseInt(process.env.REVERIE_LAZY_EMBED_BATCH ?? '100', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 100;
+}
+
+function toNodeProperties(memory: Record<string, any>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(memory).filter(([key]) => !key.startsWith('_')));
+}
+
+function isAllLowercase(value: string): boolean {
+  return value.length > 0 && value === value.toLowerCase() && value !== value.toUpperCase();
+}
+
+function capitalizeLabel(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function escapeIdentifier(value: string): string {
+  return value.replace(/`/g, '``');
+}
+
+function groupDuplicates(rows: DuplicateNodeRow[]): GroupedDuplicateNode[][] {
+  const byGroup = new Map<string, GroupedDuplicateNode[]>();
+
+  for (const row of rows) {
+    const effectiveLabel = isAllLowercase(row.label) ? capitalizeLabel(row.label) : row.label;
+    const node: GroupedDuplicateNode = {
+      ...row,
+      effectiveLabel
+    };
+    const key = `${effectiveLabel}\u0000${row.name.toLowerCase()}`;
+    const group = byGroup.get(key) ?? [];
+    group.push(node);
+    byGroup.set(key, group);
+  }
+
+  return [...byGroup.values()]
+    .filter((group) => group.length > 1)
+    .map((group) => [...group].sort(compareDuplicateNodes))
+    .sort((left, right) => {
+      const leftKey = `${left[0].effectiveLabel}/${left[0].name.toLowerCase()}`;
+      const rightKey = `${right[0].effectiveLabel}/${right[0].name.toLowerCase()}`;
+      return leftKey.localeCompare(rightKey);
+    });
+}
+
+function compareDuplicateNodes(left: GroupedDuplicateNode, right: GroupedDuplicateNode): number {
+  const leftCreatedAt = left.created_at ?? '';
+  const rightCreatedAt = right.created_at ?? '';
+  if (leftCreatedAt !== rightCreatedAt) {
+    return leftCreatedAt.localeCompare(rightCreatedAt);
+  }
+  return left.id - right.id;
+}
+
+function simulateOrphansAfterMerge(currentOrphans: number, duplicates: GroupedDuplicateNode[][]): number {
+  let orphans = currentOrphans;
+
+  for (const group of duplicates) {
+    const orphanCount = group.filter((node) => node.rel_count === 0).length;
+    if (orphanCount === 0) {
+      continue;
+    }
+
+    const allOrphans = orphanCount === group.length;
+    orphans -= allOrphans ? orphanCount - 1 : orphanCount;
+  }
+
+  return orphans;
 }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,6 +2,7 @@ import { CallToolResult, ErrorCode, McpError } from '@modelcontextprotocol/sdk/t
 import neo4j from 'neo4j-driver';
 import { Embedder, embedNodes, scrub } from '../embeddings.js';
 import { Neo4jClient } from '../neo4j-client.js';
+import { readOnlyViolation } from '../cypher-guard.js';
 import { bloatHint, contentKeys, factLikeKeys, maxProperties } from '../hygiene.js';
 import { Candidate, Ranked, SearchMode, rank } from '../search.js';
 import {
@@ -35,7 +36,21 @@ interface GroupedDuplicateNode extends DuplicateNodeRow {
   effectiveLabel: string;
 }
 
-// Blocks write clauses, subqueries and every procedure except the read-only db.* / dbms.* ones (APOC can write).
+const QUERY_ROW_LIMIT = 200;
+const QUERY_TIMEOUT_MS = 10_000;
+/** Property keys that, when both present and different, mark two same-named nodes as distinct entities. */
+const IDENTITY_KEYS = ['email', 'phone', 'website', 'company', 'organisation', 'organization'] as const;
+/** apoc.refactor.mergeNodes property strategy: survivor wins for name, timestamps and vectors; the rest combine. */
+const MERGE_PROPERTY_STRATEGY: Record<string, string> = {
+  name: 'discard',
+  created_at: 'discard',
+  embedding: 'discard',
+  name_embedding: 'discard',
+  embedding_model: 'discard',
+  embedded_at: 'discard',
+  '.*': 'combine'
+};
+
 const EMBED_NODE_CYPHER = `
   MATCH (n)
   WHERE id(n) = $id
@@ -44,7 +59,6 @@ const EMBED_NODE_CYPHER = `
       n.embedding_model = $model,
       n.embedded_at = $embeddedAt`;
 
-const READ_ONLY_CYPHER_RE = /\b(CREATE|MERGE|SET|DELETE|REMOVE|DROP|DETACH|LOAD\s+CSV)\b|\bCALL\b(?!\s+(db|dbms)\.)/i;
 
 export async function handleToolCall(
   name: string,
@@ -63,7 +77,7 @@ export async function handleToolCall(
         const limit = Math.min(args.limit ?? 10, 200);
         const query = args.query ?? '';
         const requestedMode = args.search_mode ?? 'hybrid';
-        const similarityThreshold = clamp(args.similarity_threshold ?? 0.4, 0, 1);
+        const similarityThreshold = args.similarity_threshold ?? 0.4;
         let orderBy = 'memory.created_at DESC';
         let hasCustomOrder = false;
         if (args.order_by) {
@@ -236,12 +250,16 @@ export async function handleToolCall(
           throw new McpError(ErrorCode.InvalidParams, 'Invalid query_memories arguments');
         }
 
-        if (READ_ONLY_CYPHER_RE.test(args.cypher)) {
-          throw new McpError(ErrorCode.InvalidParams, 'query_memories only supports read-only Cypher');
+        const violation = readOnlyViolation(args.cypher);
+        if (violation) {
+          throw new McpError(ErrorCode.InvalidParams, `query_memories only supports read-only Cypher: ${violation}`);
         }
 
-        const result = await neo4jClient.executeQuery(args.cypher, args.params ?? {});
-        return jsonResult(result.slice(0, 200));
+        const result = await neo4jClient.executeReadQuery(args.cypher, args.params ?? {}, {
+          limit: QUERY_ROW_LIMIT,
+          timeoutMs: QUERY_TIMEOUT_MS
+        });
+        return jsonResult(result);
       }
 
       case 'memory_stats': {
@@ -342,7 +360,7 @@ export async function handleToolCall(
 
         const duplicateRows = await neo4jClient.executeQuery<DuplicateNodeRow>(
           `MATCH (n)
-           WHERE coalesce(n.status, '') <> 'archived' AND n.name IS NOT NULL
+           WHERE coalesce(n.status, '') <> 'archived' AND n.name IS :: STRING
            RETURN id(n) AS id,
                   labels(n)[0] AS label,
                   n.name AS name,
@@ -351,6 +369,8 @@ export async function handleToolCall(
            ORDER BY labels(n)[0], toLower(n.name), n.created_at, id(n)`
         );
         const duplicates = groupDuplicates(duplicateRows);
+        const identity = await loadIdentityFields(neo4jClient, duplicates.flat().map((node) => node.id));
+        const duplicateReport: DuplicateGroupReport[] = [];
 
         let apocAvailable = true;
         try {
@@ -360,33 +380,54 @@ export async function handleToolCall(
         }
 
         let merged = 0;
-        if (!apocAvailable) {
-          if (duplicates.length > 0) {
-            notes.push(`APOC unavailable; duplicate names found: ${duplicates.map((group) => `${group[0].effectiveLabel}/${group[0].name}`).join(', ')}`);
-          }
-        } else {
-          for (const group of duplicates) {
-            const [keep, ...rest] = group;
-            merged += rest.length;
+        if (!apocAvailable && duplicates.length > 0) {
+          notes.push('APOC unavailable; duplicates were listed but not merged');
+        }
 
-            if (dryRun) {
+        for (const group of duplicates) {
+          const [keep, ...rest] = group;
+          const report: DuplicateGroupReport = {
+            label: keep.effectiveLabel,
+            name: String(keep.name),
+            keep: keep.id,
+            merged: [],
+            skipped: []
+          };
+
+          for (const duplicate of rest) {
+            const conflict = identityConflict(identity.get(keep.id), identity.get(duplicate.id));
+            if (conflict) {
+              report.skipped.push({ id: duplicate.id, reason: `different ${conflict}` });
+              continue;
+            }
+            if (!apocAvailable) {
+              report.skipped.push({ id: duplicate.id, reason: 'APOC unavailable' });
               continue;
             }
 
-            for (const duplicate of rest) {
+            if (!dryRun) {
+              // Keep the survivor's identity and vector fields; combine everything else so no value is
+              // dropped (conflicts become lists). Clearing embedding_model makes the re-embed step below
+              // refresh the merged node.
               await neo4jClient.executeQuery(
                 `MATCH (keep) WHERE id(keep) = $keepId
                  MATCH (dup) WHERE id(dup) = $dupId
-                 CALL apoc.refactor.mergeNodes([keep, dup], {properties: 'discard', mergeRels: true})
+                 CALL apoc.refactor.mergeNodes([keep, dup], {properties: $strategy, mergeRels: true})
                  YIELD node
+                 SET node.embedding_model = null
                  RETURN count(node) AS count`,
                 {
                   keepId: neo4j.int(keep.id),
-                  dupId: neo4j.int(duplicate.id)
+                  dupId: neo4j.int(duplicate.id),
+                  strategy: MERGE_PROPERTY_STRATEGY
                 }
               );
             }
+            report.merged.push(duplicate.id);
+            merged += 1;
           }
+
+          duplicateReport.push(report);
         }
 
         let reembedded = 0;
@@ -402,17 +443,19 @@ export async function handleToolCall(
           if (dryRun) {
             reembedded = nodesToEmbed.length;
           } else if (nodesToEmbed.length > 0) {
-            try {
-              for (let index = 0; index < nodesToEmbed.length; index += 50) {
-                const batch = nodesToEmbed.slice(index, index + 50).map((candidate) => ({
-                  id: candidate.id,
-                  label: candidate.label || 'Memory',
-                  props: candidate.props || {}
-                }));
+            for (let index = 0; index < nodesToEmbed.length; index += 50) {
+              const batch = nodesToEmbed.slice(index, index + 50).map((candidate) => ({
+                id: candidate.id,
+                label: candidate.label || 'Memory',
+                props: candidate.props || {}
+              }));
+              try {
                 reembedded += await persistCandidateEmbeddings(neo4jClient, embedder, batch);
+              } catch (error) {
+                console.error('Embedding unavailable for dream:', error);
+                notes.push(`re-embedding stopped after ${reembedded} of ${nodesToEmbed.length} nodes: ${error instanceof Error ? error.message : String(error)}`);
+                break;
               }
-            } catch (error) {
-              console.error('Embedding unavailable for dream:', error);
             }
           }
         }
@@ -423,8 +466,11 @@ export async function handleToolCall(
              AND NOT (n)--()
            RETURN count(n) AS count`
         );
+        const mergedGroups = duplicateReport
+          .filter((report) => report.merged.length > 0)
+          .map((report) => duplicates.find((group) => group[0].id === report.keep) ?? []);
         const orphans = dryRun
-          ? simulateOrphansAfterMerge(currentOrphanRow?.count ?? 0, duplicates)
+          ? simulateOrphansAfterMerge(currentOrphanRow?.count ?? 0, mergedGroups)
           : currentOrphanRow?.count ?? 0;
 
         const bloated = await findBloatedNodes(neo4jClient, maxProperties());
@@ -438,6 +484,7 @@ export async function handleToolCall(
           merged,
           reembedded,
           orphans,
+          duplicates: duplicateReport,
           bloated,
           apoc_available: apocAvailable,
           notes
@@ -616,6 +663,51 @@ async function fetchMemories(
   return neo4jClient.executeQuery(finalQuery, { memoryIds });
 }
 
+interface DuplicateGroupReport {
+  label: string;
+  name: string;
+  keep: number;
+  merged: number[];
+  skipped: Array<{ id: number; reason: string }>;
+}
+
+type IdentityFields = Partial<Record<(typeof IDENTITY_KEYS)[number], string>>;
+
+/** Identity-bearing properties for the nodes in duplicate groups, lower-cased for comparison. */
+async function loadIdentityFields(neo4jClient: Neo4jClient, ids: number[]): Promise<Map<number, IdentityFields>> {
+  const fields = new Map<number, IdentityFields>();
+  if (ids.length === 0) {
+    return fields;
+  }
+  const rows = await neo4jClient.executeQuery<{ id: number; props: Record<string, unknown> }>(
+    'MATCH (n) WHERE id(n) IN $ids RETURN id(n) AS id, properties(n) AS props',
+    { ids: ids.map((id) => neo4j.int(id)) }
+  );
+  for (const row of rows) {
+    const entry: IdentityFields = {};
+    for (const key of IDENTITY_KEYS) {
+      const value = row.props[key];
+      if (typeof value === 'string' && value.trim() !== '') {
+        entry[key] = value.trim().toLowerCase();
+      }
+    }
+    fields.set(row.id, entry);
+  }
+  return fields;
+}
+
+/** The first identity key both nodes carry with different values, or null when nothing distinguishes them. */
+function identityConflict(left: IdentityFields | undefined, right: IdentityFields | undefined): string | null {
+  for (const key of IDENTITY_KEYS) {
+    const a = left?.[key];
+    const b = right?.[key];
+    if (a !== undefined && b !== undefined && a !== b) {
+      return key;
+    }
+  }
+  return null;
+}
+
 interface BloatedNode {
   id: number;
   label: string;
@@ -662,10 +754,6 @@ function needsEmbedding(props: Record<string, any>, modelId: string): boolean {
   return props.embedding_model !== modelId || !Array.isArray(props.name_embedding);
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
 function getLazyEmbedBatchSize(): number {
   const raw = Number.parseInt(process.env.REVERIE_LAZY_EMBED_BATCH ?? '100', 10);
   return Number.isFinite(raw) && raw > 0 ? raw : 100;
@@ -696,7 +784,7 @@ function groupDuplicates(rows: DuplicateNodeRow[]): GroupedDuplicateNode[][] {
       ...row,
       effectiveLabel
     };
-    const key = `${effectiveLabel}\u0000${row.name.toLowerCase()}`;
+    const key = `${effectiveLabel}\u0000${String(row.name).toLowerCase()}`;
     const group = byGroup.get(key) ?? [];
     group.push(node);
     byGroup.set(key, group);
@@ -706,15 +794,15 @@ function groupDuplicates(rows: DuplicateNodeRow[]): GroupedDuplicateNode[][] {
     .filter((group) => group.length > 1)
     .map((group) => [...group].sort(compareDuplicateNodes))
     .sort((left, right) => {
-      const leftKey = `${left[0].effectiveLabel}/${left[0].name.toLowerCase()}`;
-      const rightKey = `${right[0].effectiveLabel}/${right[0].name.toLowerCase()}`;
+      const leftKey = `${left[0].effectiveLabel}/${String(left[0].name).toLowerCase()}`;
+      const rightKey = `${right[0].effectiveLabel}/${String(right[0].name).toLowerCase()}`;
       return leftKey.localeCompare(rightKey);
     });
 }
 
 function compareDuplicateNodes(left: GroupedDuplicateNode, right: GroupedDuplicateNode): number {
-  const leftCreatedAt = left.created_at ?? '';
-  const rightCreatedAt = right.created_at ?? '';
+  const leftCreatedAt = String(left.created_at ?? '');
+  const rightCreatedAt = String(right.created_at ?? '');
   if (leftCreatedAt !== rightCreatedAt) {
     return leftCreatedAt.localeCompare(rightCreatedAt);
   }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -3,7 +3,7 @@ import neo4j from 'neo4j-driver';
 import { Embedder, embedNodes, scrub } from '../embeddings.js';
 import { Neo4jClient } from '../neo4j-client.js';
 import { readOnlyViolation } from '../cypher-guard.js';
-import { bloatHint, contentKeys, factLikeKeys, maxProperties } from '../hygiene.js';
+import { bloatHint, contentKeys, factLikeKeys, lazyEmbedBatch, maxProperties } from '../hygiene.js';
 import { Candidate, Ranked, SearchMode, rank } from '../search.js';
 import {
   isCreateConnectionArgs,
@@ -106,7 +106,11 @@ export async function handleToolCall(
           baseQuery += ` WHERE ${conditions.join(' AND ')}`;
         }
 
-        baseQuery += ' RETURN id(memory) AS id, labels(memory)[0] AS label, properties(memory) AS props';
+        // Keyword mode never needs the stored vectors, so leave them out of the wire payload.
+        const propsProjection = requestedMode === 'keyword'
+          ? 'memory {.*, embedding: null, name_embedding: null}'
+          : 'properties(memory)';
+        baseQuery += ` RETURN id(memory) AS id, labels(memory)[0] AS label, ${propsProjection} AS props ORDER BY id(memory)`;
         const rawCandidates = await neo4jClient.executeQuery<SearchCandidate>(baseQuery, queryParams);
         const candidates = rawCandidates.map((candidate) => ({
           id: candidate.id,
@@ -394,8 +398,13 @@ export async function handleToolCall(
             skipped: []
           };
 
+          // The survivor absorbs the identity fields of everything merged into it, so later
+          // duplicates are compared against the accumulated set, not the pre-merge snapshot.
+          const keepIdentity: IdentityFields = { ...(identity.get(keep.id) ?? {}) };
+
           for (const duplicate of rest) {
-            const conflict = identityConflict(identity.get(keep.id), identity.get(duplicate.id));
+            const duplicateIdentity = identity.get(duplicate.id);
+            const conflict = identityConflict(keepIdentity, duplicateIdentity);
             if (conflict) {
               report.skipped.push({ id: duplicate.id, reason: `different ${conflict}` });
               continue;
@@ -423,6 +432,12 @@ export async function handleToolCall(
                 }
               );
             }
+            for (const key of IDENTITY_KEYS) {
+              const value = duplicateIdentity?.[key];
+              if (value !== undefined && keepIdentity[key] === undefined) {
+                keepIdentity[key] = value;
+              }
+            }
             report.merged.push(duplicate.id);
             merged += 1;
           }
@@ -432,19 +447,30 @@ export async function handleToolCall(
 
         let reembedded = 0;
         if (embedder) {
-          const nodesToEmbed = await neo4jClient.executeQuery<SearchCandidate>(
-            `MATCH (n)
-             WHERE n.embedding_model IS NULL OR n.embedding_model <> $model OR n.name_embedding IS NULL
-             RETURN id(n) AS id, labels(n)[0] AS label, properties(n) AS props
-             ORDER BY id(n)`,
-            { model: embedder.id }
-          );
-
+          const staleWhere = '(n.embedding_model IS NULL OR n.embedding_model <> $model OR n.name_embedding IS NULL)';
           if (dryRun) {
-            reembedded = nodesToEmbed.length;
-          } else if (nodesToEmbed.length > 0) {
-            for (let index = 0; index < nodesToEmbed.length; index += 50) {
-              const batch = nodesToEmbed.slice(index, index + 50).map((candidate) => ({
+            const [staleRow] = await neo4jClient.executeQuery<{ count: number }>(
+              `MATCH (n) WHERE ${staleWhere} RETURN count(n) AS count`,
+              { model: embedder.id }
+            );
+            reembedded = staleRow?.count ?? 0;
+          } else {
+            // Page through stale nodes by id so a large graph is never materialised at once, and
+            // leave the stored vectors out of the wire payload.
+            let cursor = -1;
+            for (;;) {
+              const page = await neo4jClient.executeQuery<SearchCandidate>(
+                `MATCH (n)
+                 WHERE id(n) > $cursor AND ${staleWhere}
+                 RETURN id(n) AS id, labels(n)[0] AS label, n {.*, embedding: null, name_embedding: null} AS props
+                 ORDER BY id(n) LIMIT 50`,
+                { model: embedder.id, cursor: neo4j.int(cursor) }
+              );
+              if (page.length === 0) {
+                break;
+              }
+              cursor = page[page.length - 1].id;
+              const batch = page.map((candidate) => ({
                 id: candidate.id,
                 label: candidate.label || 'Memory',
                 props: candidate.props || {}
@@ -453,7 +479,7 @@ export async function handleToolCall(
                 reembedded += await persistCandidateEmbeddings(neo4jClient, embedder, batch);
               } catch (error) {
                 console.error('Embedding unavailable for dream:', error);
-                notes.push(`re-embedding stopped after ${reembedded} of ${nodesToEmbed.length} nodes: ${error instanceof Error ? error.message : String(error)}`);
+                notes.push(`re-embedding stopped after ${reembedded} nodes: ${error instanceof Error ? error.message : String(error)}`);
                 break;
               }
             }
@@ -546,14 +572,18 @@ async function rankCandidates(
       effectiveMode = 'keyword';
     } else {
       try {
-        const lazyBatch = getLazyEmbedBatchSize();
+        const lazyBatch = lazyEmbedBatch();
         const candidatesToEmbed = candidates.filter((candidate) => needsEmbedding(candidate.props, embedder.id)).slice(0, lazyBatch);
 
         if (candidatesToEmbed.length > 0) {
           await persistCandidateEmbeddings(neo4jClient, embedder, candidatesToEmbed);
         }
 
-        [queryEmbedding] = await embedder.embed([trimmedQuery]);
+        const [vector] = await embedder.embed([trimmedQuery]);
+        if (!Array.isArray(vector) || vector.length === 0) {
+          throw new Error('Embedding provider returned no vector for the query');
+        }
+        queryEmbedding = vector;
       } catch (error) {
         console.error('Embedding unavailable for search_memories:', error);
         effectiveMode = 'keyword';
@@ -757,11 +787,6 @@ function jsonResult(value: unknown): CallToolResult {
 /** Stale when embedded by another model/provider, or before the name vector was introduced. */
 function needsEmbedding(props: Record<string, any>, modelId: string): boolean {
   return props.embedding_model !== modelId || !Array.isArray(props.name_embedding);
-}
-
-function getLazyEmbedBatchSize(): number {
-  const raw = Number.parseInt(process.env.REVERIE_LAZY_EMBED_BATCH ?? '100', 10);
-  return Number.isFinite(raw) && raw > 0 ? raw : 100;
 }
 
 function toNodeProperties(memory: Record<string, any>): Record<string, unknown> {

--- a/src/hygiene.ts
+++ b/src/hygiene.ts
@@ -31,6 +31,19 @@ export function factLikeKeys(props: Record<string, unknown>): string[] {
   });
 }
 
+export const DEFAULT_LAZY_EMBED_BATCH = 100;
+export const MAX_LAZY_EMBED_BATCH = 1000;
+
+/** REVERIE_LAZY_EMBED_BATCH: stale candidates embedded per search; whole number 1..1000, else the default. */
+export function lazyEmbedBatch(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = (env.REVERIE_LAZY_EMBED_BATCH ?? '').trim();
+  if (!/^\d+$/.test(raw)) {
+    return DEFAULT_LAZY_EMBED_BATCH;
+  }
+  const value = Number(raw);
+  return value >= 1 && value <= MAX_LAZY_EMBED_BATCH ? value : DEFAULT_LAZY_EMBED_BATCH;
+}
+
 export function bloatHint(name: string, count: number, limit: number): string {
   return `"${name}" now has ${count} properties (limit ${limit}). The graph maps entities and relationships; ` +
     'keep only durable attributes here. Fold dated facts and episodes into a short attribute, a relationship, ' +

--- a/src/hygiene.ts
+++ b/src/hygiene.ts
@@ -1,0 +1,32 @@
+import { EMBEDDING_FIELDS } from './embeddings.js';
+
+/** Above this many real properties a node is "bloated": facts are being piled on instead of modelled. */
+export const DEFAULT_MAX_PROPERTIES = 30;
+
+const HOUSEKEEPING = new Set<string>([...EMBEDDING_FIELDS, 'created_at', 'updated_at', 'status', 'archived_at']);
+const DATE_SUFFIX_RE = /(_|-)\d{4}(_|-)\d{2}(_|-)\d{2}$/;
+const LONG_TEXT = 120;
+
+export function maxProperties(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number.parseInt(env.REVERIE_MAX_PROPERTIES ?? '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PROPERTIES;
+}
+
+/** User-visible properties only: no `_id`-style metadata, timestamps, status or embedding fields. */
+export function contentKeys(props: Record<string, unknown>): string[] {
+  return Object.keys(props).filter((key) => !key.startsWith('_') && !HOUSEKEEPING.has(key));
+}
+
+/** Keys that look like facts or episodes rather than attributes: dated names, or long prose values. */
+export function factLikeKeys(props: Record<string, unknown>): string[] {
+  return contentKeys(props).filter((key) => {
+    const value = props[key];
+    return DATE_SUFFIX_RE.test(key) || (typeof value === 'string' && value.length > LONG_TEXT);
+  });
+}
+
+export function bloatHint(name: string, count: number, limit: number): string {
+  return `"${name}" now has ${count} properties (limit ${limit}). The graph maps entities and relationships; ` +
+    'keep only durable attributes here. Fold dated facts and episodes into a short attribute, a relationship, ' +
+    'or your notes. See get_guidance("best-practices").';
+}

--- a/src/hygiene.ts
+++ b/src/hygiene.ts
@@ -2,14 +2,20 @@ import { EMBEDDING_FIELDS } from './embeddings.js';
 
 /** Above this many real properties a node is "bloated": facts are being piled on instead of modelled. */
 export const DEFAULT_MAX_PROPERTIES = 30;
+export const MAX_PROPERTIES_CAP = 500;
 
 const HOUSEKEEPING = new Set<string>([...EMBEDDING_FIELDS, 'created_at', 'updated_at', 'status', 'archived_at']);
 const DATE_SUFFIX_RE = /(_|-)\d{4}(_|-)\d{2}(_|-)\d{2}$/;
 const LONG_TEXT = 120;
 
+/** REVERIE_MAX_PROPERTIES must be a whole number in 1..MAX_PROPERTIES_CAP; anything else falls back to the default. */
 export function maxProperties(env: NodeJS.ProcessEnv = process.env): number {
-  const raw = Number.parseInt(env.REVERIE_MAX_PROPERTIES ?? '', 10);
-  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PROPERTIES;
+  const raw = (env.REVERIE_MAX_PROPERTIES ?? '').trim();
+  if (!/^\d+$/.test(raw)) {
+    return DEFAULT_MAX_PROPERTIES;
+  }
+  const value = Number(raw);
+  return value >= 1 && value <= MAX_PROPERTIES_CAP ? value : DEFAULT_MAX_PROPERTIES;
 }
 
 /** User-visible properties only: no `_id`-style metadata, timestamps, status or embedding fields. */

--- a/src/neo4j-client.ts
+++ b/src/neo4j-client.ts
@@ -1,3 +1,4 @@
+import { cypherIdentifier } from './types.js';
 import neo4j, { Driver, Integer, Node, QueryResult, Record as Neo4jRecord, Relationship, Session } from 'neo4j-driver';
 
 export interface Neo4jQueryParams {
@@ -123,11 +124,11 @@ export class Neo4jClient {
   }
 
   async getNodes(label: string): Promise<any[]> {
-    return this.executeQuery(`MATCH (n:${label}) RETURN n as memory`);
+    return this.executeQuery(`MATCH (n:${cypherIdentifier(label)}) RETURN n as memory`);
   }
 
   async createNode(label: string, properties: Neo4jQueryParams): Promise<any> {
-    const result = await this.executeQuery(`CREATE (n:${label} $props) RETURN n as memory`, { props: properties });
+    const result = await this.executeQuery(`CREATE (n:${cypherIdentifier(label)} $props) RETURN n as memory`, { props: properties });
     return result[0];
   }
 
@@ -135,7 +136,7 @@ export class Neo4jClient {
     const result = await this.executeQuery(
       `MATCH (a), (b)
        WHERE id(a) = $fromId AND id(b) = $toId
-       CREATE (a)-[r:${relationType} $props]->(b)
+       CREATE (a)-[r:${cypherIdentifier(relationType)} $props]->(b)
        RETURN r as relationship`,
       {
         fromId: neo4j.int(fromNodeId),
@@ -161,7 +162,7 @@ export class Neo4jClient {
 
   async updateRelationship(fromNodeId: number, toNodeId: number, relationType: string, properties: Neo4jQueryParams): Promise<any> {
     const result = await this.executeQuery(
-      `MATCH (a)-[r:${relationType}]->(b)
+      `MATCH (a)-[r:${cypherIdentifier(relationType)}]->(b)
        WHERE id(a) = $fromId AND id(b) = $toId
        SET r += $props
        RETURN r as relationship`,
@@ -188,7 +189,7 @@ export class Neo4jClient {
 
   async deleteRelationship(fromNodeId: number, toNodeId: number, relationType: string): Promise<any> {
     const result = await this.executeQuery(
-      `MATCH (a)-[r:${relationType}]->(b)
+      `MATCH (a)-[r:${cypherIdentifier(relationType)}]->(b)
        WHERE id(a) = $fromId AND id(b) = $toId
        DELETE r
        RETURN count(r) as deletedCount`,

--- a/src/neo4j-client.ts
+++ b/src/neo4j-client.ts
@@ -34,6 +34,29 @@ export class Neo4jClient {
       };
     }
 
+    if (neo4j.isPath(value)) {
+      return {
+        start: this.convertNestedIntegers(value.start),
+        end: this.convertNestedIntegers(value.end),
+        segments: value.segments.map((segment) => ({
+          start: this.convertNestedIntegers(segment.start),
+          relationship: this.convertNestedIntegers(segment.relationship),
+          end: this.convertNestedIntegers(segment.end),
+        })),
+      };
+    }
+
+    if (neo4j.isPoint(value)) {
+      return { srid: this.convertNestedIntegers(value.srid), x: value.x, y: value.y, z: value.z };
+    }
+
+    if (
+      neo4j.isDate(value) || neo4j.isDateTime(value) || neo4j.isLocalDateTime(value) ||
+      neo4j.isTime(value) || neo4j.isLocalTime(value) || neo4j.isDuration(value)
+    ) {
+      return value.toString();
+    }
+
     if (Array.isArray(value)) {
       return value.map((item) => this.convertNestedIntegers(item));
     }
@@ -49,19 +72,51 @@ export class Neo4jClient {
     return value;
   }
 
+  private recordToObject<T>(record: Neo4jRecord): T {
+    const obj: { [key: string]: any } = {};
+    for (const key of record.keys) {
+      obj[key as string] = this.convertNestedIntegers(record.get(key));
+    }
+    return obj as T;
+  }
+
   async executeQuery<T = any>(query: string, params: Neo4jQueryParams = {}): Promise<T[]> {
     const session: Session = this.driver.session({
       database: this.database
     });
     try {
       const result: QueryResult = await session.run(query, params);
-      return result.records.map((record: Neo4jRecord) => {
-        const obj: { [key: string]: any } = {};
-        for (const key of record.keys) {
-          obj[key as string] = this.convertNestedIntegers(record.get(key));
+      return result.records.map((record: Neo4jRecord) => this.recordToObject<T>(record));
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Caller-supplied Cypher: runs in a READ transaction (the server rejects writes), stops
+   * consuming after `limit` records instead of materialising the whole result, and is
+   * bounded by a transaction timeout.
+   */
+  async executeReadQuery<T = any>(
+    query: string,
+    params: Neo4jQueryParams,
+    options: { limit: number; timeoutMs: number }
+  ): Promise<T[]> {
+    const session: Session = this.driver.session({
+      database: this.database,
+      defaultAccessMode: neo4j.session.READ
+    });
+    try {
+      return await session.executeRead(async (tx) => {
+        const rows: T[] = [];
+        for await (const record of tx.run(query, params)) {
+          rows.push(this.recordToObject<T>(record));
+          if (rows.length >= options.limit) {
+            break;
+          }
         }
-        return obj as T;
-      });
+        return rows;
+      }, { timeout: options.timeoutMs });
     } finally {
       await session.close();
     }

--- a/src/neo4j-client.ts
+++ b/src/neo4j-client.ts
@@ -1,4 +1,4 @@
-import neo4j, { Driver, Session, QueryResult, Record as Neo4jRecord, Node, Relationship, Integer } from 'neo4j-driver';
+import neo4j, { Driver, Integer, Node, QueryResult, Record as Neo4jRecord, Relationship, Session } from 'neo4j-driver';
 
 export interface Neo4jQueryParams {
   [key: string]: any;
@@ -17,11 +17,27 @@ export class Neo4jClient {
     if (value instanceof Integer) {
       return value.toNumber();
     }
-    
-    if (Array.isArray(value)) {
-      return value.map(item => this.convertNestedIntegers(item));
+
+    if (value instanceof Node) {
+      return {
+        ...this.convertNestedIntegers(value.properties),
+        _id: value.identity.toNumber(),
+        _labels: value.labels,
+      };
     }
-    
+
+    if (value instanceof Relationship) {
+      return {
+        ...this.convertNestedIntegers(value.properties),
+        _id: value.identity.toNumber(),
+        _type: value.type,
+      };
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => this.convertNestedIntegers(item));
+    }
+
     if (value && typeof value === 'object' && value.constructor === Object) {
       const converted: { [key: string]: any } = {};
       for (const [key, val] of Object.entries(value)) {
@@ -29,7 +45,7 @@ export class Neo4jClient {
       }
       return converted;
     }
-    
+
     return value;
   }
 
@@ -42,17 +58,7 @@ export class Neo4jClient {
       return result.records.map((record: Neo4jRecord) => {
         const obj: { [key: string]: any } = {};
         for (const key of record.keys) {
-          const value = record.get(key);
-          if (value instanceof Node || value instanceof Relationship) {
-            obj[key as string] = {
-              ...this.convertNestedIntegers(value.properties),
-              _id: value.identity.toNumber(),
-              _labels: value instanceof Node ? value.labels : undefined,
-              _type: value instanceof Relationship ? value.type : undefined,
-            };
-          } else {
-            obj[key as string] = this.convertNestedIntegers(value);
-          }
+          obj[key as string] = this.convertNestedIntegers(record.get(key));
         }
         return obj as T;
       });

--- a/src/neo4j-client.ts
+++ b/src/neo4j-client.ts
@@ -103,6 +103,12 @@ export class Neo4jClient {
     params: Neo4jQueryParams,
     options: { limit: number; timeoutMs: number }
   ): Promise<T[]> {
+    if (!Number.isSafeInteger(options.limit) || options.limit < 0) {
+      throw new Error('Query limit must be a non-negative integer');
+    }
+    if (options.limit === 0) {
+      return [];
+    }
     const session: Session = this.driver.session({
       database: this.database,
       defaultAccessMode: neo4j.session.READ

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,117 @@
+import { EMBEDDING_FIELDS, cosine } from './embeddings.js';
+
+export type SearchMode = 'hybrid' | 'keyword' | 'semantic';
+
+export interface Candidate {
+  id: number;
+  props: Record<string, any>;
+}
+
+export interface Ranked {
+  id: number;
+  score: number;
+  match: 'keyword' | 'semantic';
+}
+
+export function keywordMatches(query: string, props: Record<string, any>): boolean {
+  const trimmedQuery = query.trim().toLowerCase();
+  if (!trimmedQuery) {
+    return true;
+  }
+
+  const words = trimmedQuery.split(/\s+/);
+  const embeddingFieldSet = new Set<string>(EMBEDDING_FIELDS);
+
+  for (const [key, value] of Object.entries(props)) {
+    if (embeddingFieldSet.has(key) || value === null || value === undefined) {
+      continue;
+    }
+
+    const haystack = Array.isArray(value)
+      ? value.map((item) => item?.toString() || '').join(' ').toLowerCase()
+      : value.toString().toLowerCase();
+
+    if (words.some((word) => haystack.includes(word))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function rank(candidates: Candidate[], opts: {
+  query: string;
+  mode: SearchMode;
+  queryEmbedding?: number[];
+  threshold: number;
+  modelId?: string;
+}): Ranked[] {
+  const trimmedQuery = opts.query.trim();
+
+  if (!trimmedQuery) {
+    return [...candidates]
+      .map((candidate) => ({ id: candidate.id, score: 0, match: 'keyword' as const }))
+      .sort(compareRankedBy(candidates));
+  }
+
+  const results: Ranked[] = [];
+  const seen = new Set<number>();
+
+  if (opts.mode === 'hybrid' || opts.mode === 'keyword') {
+    for (const candidate of candidates) {
+      if (keywordMatches(trimmedQuery, candidate.props)) {
+        results.push({ id: candidate.id, score: 1, match: 'keyword' });
+        seen.add(candidate.id);
+      }
+    }
+  }
+
+  if ((opts.mode === 'hybrid' || opts.mode === 'semantic') && opts.queryEmbedding && opts.modelId) {
+    for (const candidate of candidates) {
+      if (seen.has(candidate.id)) {
+        continue;
+      }
+
+      if (candidate.props.embedding_model !== opts.modelId) {
+        continue;
+      }
+
+      const score = Math.max(
+        similarity(opts.queryEmbedding, candidate.props.embedding),
+        similarity(opts.queryEmbedding, candidate.props.name_embedding)
+      );
+      if (score >= opts.threshold) {
+        results.push({ id: candidate.id, score, match: 'semantic' });
+      }
+    }
+  }
+
+  return results.sort(compareRankedBy(candidates));
+}
+
+function similarity(query: number[], vector: unknown): number {
+  return Array.isArray(vector) ? cosine(query, vector.map((item) => Number(item))) : 0;
+}
+
+function compareRankedBy(candidates: Candidate[]): (left: Ranked, right: Ranked) => number {
+  const createdAt = new Map<number, string>(
+    candidates.map((candidate) => [
+      candidate.id,
+      typeof candidate.props.created_at === 'string' ? candidate.props.created_at : ''
+    ])
+  );
+
+  return (left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+
+    const leftCreatedAt = createdAt.get(left.id) ?? '';
+    const rightCreatedAt = createdAt.get(right.id) ?? '';
+    if (rightCreatedAt !== leftCreatedAt) {
+      return rightCreatedAt.localeCompare(leftCreatedAt);
+    }
+
+    return left.id - right.id;
+  };
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,4 +1,5 @@
-import { EMBEDDING_FIELDS, cosine } from './embeddings.js';
+import { cosine } from './embeddings.js';
+import { contentKeys } from './hygiene.js';
 
 export type SearchMode = 'hybrid' | 'keyword' | 'semantic';
 
@@ -20,10 +21,11 @@ export function keywordMatches(query: string, props: Record<string, any>): boole
   }
 
   const words = trimmedQuery.split(/\s+/);
-  const embeddingFieldSet = new Set<string>(EMBEDDING_FIELDS);
 
-  for (const [key, value] of Object.entries(props)) {
-    if (embeddingFieldSet.has(key) || value === null || value === undefined) {
+  // Only user content is searchable: timestamps, status and embedding fields never match.
+  for (const key of contentKeys(props)) {
+    const value = props[key];
+    if (value === null || value === undefined) {
       continue;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,20 +1,22 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { Neo4jClient } from './neo4j-client.js';
-import { Neo4jServerConfig } from './types.js';
-import { tools } from './tools/definitions.js';
+import { Embedder, createEmbedder } from './embeddings.js';
 import { handleToolCall } from './handlers/index.js';
+import { Neo4jClient } from './neo4j-client.js';
+import { tools } from './tools/definitions.js';
+import { Neo4jServerConfig } from './types.js';
 
 export class Neo4jServer {
   private server: Server;
   private neo4j: Neo4jClient | null;
+  private embedder: Embedder | null;
 
   constructor(config?: Neo4jServerConfig) {
     this.server = new Server(
       {
         name: 'reverie',
-        version: '1.0.0',
+        version: '0.4.0',
       },
       {
         capabilities: {
@@ -24,9 +26,9 @@ export class Neo4jServer {
     );
 
     this.neo4j = config ? new Neo4jClient(config.uri, config.username, config.password, config.database) : null;
+    this.embedder = config ? createEmbedder() : null;
     this.setupToolHandlers();
 
-    // Error handling
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     process.on('SIGINT', async () => {
       await this.close();
@@ -35,12 +37,10 @@ export class Neo4jServer {
   }
 
   private setupToolHandlers(): void {
-    // Tool list handler
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools,
     }));
 
-    // Tool execution handler
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       if (!this.neo4j) {
         return {
@@ -54,7 +54,7 @@ export class Neo4jServer {
         };
       }
       const { name, arguments: args } = request.params;
-      return handleToolCall(name, args, this.neo4j);
+      return handleToolCall(name, args, this.neo4j, this.embedder);
     });
   }
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -23,7 +23,9 @@ export const tools: Tool[] = [
           description: 'Filter by memory label',
         },
         depth: {
-          type: 'number',
+          type: 'integer',
+          minimum: 0,
+          maximum: 5,
           description: 'Relationship depth to include, 0 to 5, defaults to 1',
         },
         order_by: {
@@ -31,7 +33,9 @@ export const tools: Tool[] = [
           description: 'Sort order such as created_at DESC, name ASC',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
+          maximum: 200,
           description: 'Maximum results to return, 1 to 200, defaults to 10',
         },
         since_date: {
@@ -45,6 +49,8 @@ export const tools: Tool[] = [
         },
         similarity_threshold: {
           type: 'number',
+          minimum: 0,
+          maximum: 1,
           description: 'Semantic similarity threshold, 0 to 1 inclusive, defaults to 0.4.',
         },
       },

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -24,7 +24,7 @@ export const tools: Tool[] = [
         },
         depth: {
           type: 'number',
-          description: 'Relationship depth to include, defaults to 1',
+          description: 'Relationship depth to include, 0 to 5, defaults to 1',
         },
         order_by: {
           type: 'string',
@@ -32,7 +32,7 @@ export const tools: Tool[] = [
         },
         limit: {
           type: 'number',
-          description: 'Maximum results to return, defaults to 10, max 200',
+          description: 'Maximum results to return, 1 to 200, defaults to 10',
         },
         since_date: {
           type: 'string',
@@ -45,10 +45,11 @@ export const tools: Tool[] = [
         },
         similarity_threshold: {
           type: 'number',
-          description: 'Semantic similarity threshold from 0 to 1, defaults to 0.4.',
+          description: 'Semantic similarity threshold, 0 to 1 inclusive, defaults to 0.4.',
         },
       },
       required: [],
+      additionalProperties: false,
     },
   },
   {
@@ -205,6 +206,7 @@ export const tools: Tool[] = [
         },
       },
       required: ['cypher'],
+      additionalProperties: false,
     },
   },
   {
@@ -214,6 +216,7 @@ export const tools: Tool[] = [
       type: 'object',
       properties: {},
       required: [],
+      additionalProperties: false,
     },
   },
   {
@@ -228,6 +231,7 @@ export const tools: Tool[] = [
         },
       },
       required: [],
+      additionalProperties: false,
     },
   },
   guidanceTool,

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -3,20 +3,20 @@ import { guidanceTool } from './guidance-tool.js';
 
 /**
  * MCP Neo4j Agent Memory Tools
- * 
+ *
  * Tool descriptions are kept simple to avoid breaking prompt templates in 3rd party solutions.
  * Use the get_guidance tool to access detailed information about labels, relationships, and best practices.
  */
 export const tools: Tool[] = [
   {
     name: 'search_memories',
-    description: 'Search and retrieve memories from the knowledge graph',
+    description: 'Hybrid keyword + semantic search across the knowledge graph. "Ben Weeks" can also find "Benjamin Weeks" and each result includes _score and _match.',
     inputSchema: {
       type: 'object',
       properties: {
         query: {
           type: 'string',
-          description: 'Search text to find in any property (searches for ANY word - e.g. "Ben Weeks" finds memories containing "Ben" OR "Weeks")',
+          description: 'Search text to find in any property. Keyword mode matches any word, while semantic mode can surface close meanings and name variants.',
         },
         label: {
           type: 'string',
@@ -37,6 +37,15 @@ export const tools: Tool[] = [
         since_date: {
           type: 'string',
           description: 'ISO date string to filter memories created after this date (e.g., "2024-01-01" or "2024-01-01T00:00:00Z")',
+        },
+        search_mode: {
+          type: 'string',
+          enum: ['hybrid', 'keyword', 'semantic'],
+          description: 'Search mode: hybrid (default), keyword-only, or semantic-only.',
+        },
+        similarity_threshold: {
+          type: 'number',
+          description: 'Semantic similarity threshold from 0 to 1, defaults to 0.4.',
         },
       },
       required: [],
@@ -176,6 +185,48 @@ export const tools: Tool[] = [
     inputSchema: {
       type: 'object',
       properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'query_memories',
+    description: 'Run a read-only Cypher query and return up to 200 scrubbed rows.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        cypher: {
+          type: 'string',
+          description: 'Read-only Cypher to execute.',
+        },
+        params: {
+          type: 'object',
+          description: 'Optional parameter map for the Cypher query.',
+          additionalProperties: true,
+        },
+      },
+      required: ['cypher'],
+    },
+  },
+  {
+    name: 'memory_stats',
+    description: 'Summarize node, relationship, label, embedding, and orphan counts for the graph.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'dream',
+    description: 'Deterministically relabel, merge duplicates, and refresh embeddings, with an optional dry run report.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        dry_run: {
+          type: 'boolean',
+          description: 'If true, report planned changes without writing them.',
+        },
+      },
       required: [],
     },
   },

--- a/src/tools/guidance-tool.ts
+++ b/src/tools/guidance-tool.ts
@@ -155,8 +155,8 @@ Use UPPERCASE for relationship types:
 
 **Searching**
 - Empty query string returns all memories
-- Use search_mode: "hybrid" for the best default blend of keyword and semantic matching
-- Use search_mode: "keyword" for exact substring-style recall, or search_mode: "semantic" for meaning-first recall
+- Use search_mode: "hybrid" (the default) to return keyword matches first, then semantic matches above the threshold
+- Use search_mode: "keyword" to match any word of the query as a substring of any property, or search_mode: "semantic" for meaning-first recall
 - Lower similarity_threshold (for example 0.35) to widen semantic matches, or raise it (for example 0.7) to be stricter
 - Results include _score and _match so you can explain why something was returned
 - Use label parameter to filter by type

--- a/src/tools/guidance-tool.ts
+++ b/src/tools/guidance-tool.ts
@@ -139,6 +139,14 @@ Use UPPERCASE for relationship types:
 - 'created_at' is automatic if not provided
 - IMMEDIATELY after creating, connect it to related memories
 
+**What belongs in the graph**
+- The graph is a map of entities and how they relate: people, organisations, projects, products, places, animals, concepts. It is not a notebook
+- A property is a durable attribute of an entity: email, role, phone, website, birthday, a preference you'd still want next year
+- Episodes (a call, an email thread, a day's events) mostly belong in your notes or diary. Store in the graph only what they taught you about an entity or a relationship, kept short
+- Prefer a relationship over a property when the fact is about two entities: Ben -[USES {note: "camera on, wants fixes verified"}]-> Teams calls, rather than a paragraph on Ben
+- Make an episode its own memory (e.g. meeting, decision) only when the episode itself is something you'll need to find again
+- A node with dozens of properties is a smell: update_memory returns a _hint past the limit, and dream lists such nodes under "bloated". When you sleep, fold each fact-like key into a short attribute, a relationship, or your notes, then remove it
+
 **Building Connections**
 - After creating any memory, ask: "What existing memories relate to this?"
 - Create connections for: people→organizations, people→projects, people→skills

--- a/src/tools/guidance-tool.ts
+++ b/src/tools/guidance-tool.ts
@@ -147,6 +147,10 @@ Use UPPERCASE for relationship types:
 
 **Searching**
 - Empty query string returns all memories
+- Use search_mode: "hybrid" for the best default blend of keyword and semantic matching
+- Use search_mode: "keyword" for exact substring-style recall, or search_mode: "semantic" for meaning-first recall
+- Lower similarity_threshold (for example 0.35) to widen semantic matches, or raise it (for example 0.7) to be stricter
+- Results include _score and _match so you can explain why something was returned
 - Use label parameter to filter by type
 - Increase depth to include more relationships (depth=2 or 3 for rich context)
 - Default limit is 10, max is 200

--- a/src/tools/guidance-tool.ts
+++ b/src/tools/guidance-tool.ts
@@ -156,7 +156,7 @@ Use UPPERCASE for relationship types:
 **Searching**
 - Empty query string returns all memories
 - Use search_mode: "hybrid" (the default) to return keyword matches first, then semantic matches above the threshold
-- Use search_mode: "keyword" to match any word of the query as a substring of any property, or search_mode: "semantic" for meaning-first recall
+- Use search_mode: "keyword" to match any word of the query as a substring of any searchable content property (not timestamps, status or embedding fields), or search_mode: "semantic" for meaning-first recall
 - Lower similarity_threshold (for example 0.35) to widen semantic matches, or raise it (for example 0.7) to be stricter
 - Results include _score and _match so you can explain why something was returned
 - Use label parameter to filter by type

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,21 +67,41 @@ export interface DreamArgs {
   dry_run?: boolean;
 }
 
+export const SEARCH_MAX_LIMIT = 200;
+export const SEARCH_MAX_DEPTH = 5;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function isIntegerInRange(value: unknown, min: number, max: number): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max;
+}
+
 export function isCreateMemoryArgs(args: unknown): args is CreateMemoryArgs {
   return typeof args === 'object' && args !== null && typeof (args as CreateMemoryArgs).label === 'string' && typeof (args as CreateMemoryArgs).properties === 'object';
 }
 
+const SEARCH_KEYS = ['query', 'label', 'depth', 'order_by', 'limit', 'since_date', 'search_mode', 'similarity_threshold'] as const;
+
 export function isSearchMemoriesArgs(args: unknown): args is SearchMemoriesArgs {
-  if (typeof args !== 'object' || args === null) return false;
+  if (!isPlainObject(args) || !hasOnlyKeys(args, SEARCH_KEYS)) return false;
   const searchArgs = args as SearchMemoriesArgs;
   if (searchArgs.query !== undefined && typeof searchArgs.query !== 'string') return false;
   if (searchArgs.label !== undefined && typeof searchArgs.label !== 'string') return false;
-  if (searchArgs.depth !== undefined && typeof searchArgs.depth !== 'number') return false;
+  if (searchArgs.depth !== undefined && !isIntegerInRange(searchArgs.depth, 0, SEARCH_MAX_DEPTH)) return false;
   if (searchArgs.order_by !== undefined && typeof searchArgs.order_by !== 'string') return false;
-  if (searchArgs.limit !== undefined && typeof searchArgs.limit !== 'number') return false;
+  if (searchArgs.limit !== undefined && !isIntegerInRange(searchArgs.limit, 1, SEARCH_MAX_LIMIT)) return false;
   if (searchArgs.since_date !== undefined && typeof searchArgs.since_date !== 'string') return false;
   if (searchArgs.search_mode !== undefined && !['hybrid', 'keyword', 'semantic'].includes(searchArgs.search_mode)) return false;
-  if (searchArgs.similarity_threshold !== undefined && typeof searchArgs.similarity_threshold !== 'number') return false;
+  if (searchArgs.similarity_threshold !== undefined) {
+    const threshold = searchArgs.similarity_threshold;
+    if (typeof threshold !== 'number' || !Number.isFinite(threshold) || threshold < 0 || threshold > 1) return false;
+  }
   return true;
 }
 
@@ -138,19 +158,19 @@ export function isListMemoryLabelsArgs(args: unknown): args is ListMemoryLabelsA
 }
 
 export function isQueryMemoriesArgs(args: unknown): args is QueryMemoriesArgs {
-  if (typeof args !== 'object' || args === null) return false;
-  const queryArgs = args as QueryMemoriesArgs;
-  if (typeof queryArgs.cypher !== 'string') return false;
-  if (queryArgs.params !== undefined && (typeof queryArgs.params !== 'object' || queryArgs.params === null || Array.isArray(queryArgs.params))) return false;
+  if (!isPlainObject(args) || !hasOnlyKeys(args, ['cypher', 'params'])) return false;
+  const queryArgs = args as unknown as QueryMemoriesArgs;
+  if (typeof queryArgs.cypher !== 'string' || queryArgs.cypher.trim() === '') return false;
+  if (queryArgs.params !== undefined && !isPlainObject(queryArgs.params)) return false;
   return true;
 }
 
 export function isMemoryStatsArgs(args: unknown): args is MemoryStatsArgs {
-  return typeof args === 'object' && args !== null;
+  return isPlainObject(args) && hasOnlyKeys(args, []);
 }
 
 export function isDreamArgs(args: unknown): args is DreamArgs {
-  if (typeof args !== 'object' || args === null) return false;
+  if (!isPlainObject(args) || !hasOnlyKeys(args, ['dry_run'])) return false;
   const dreamArgs = args as DreamArgs;
   if (dreamArgs.dry_run !== undefined && typeof dreamArgs.dry_run !== 'boolean') return false;
   return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface SearchMemoriesArgs {
   order_by?: string;
   limit?: number;
   since_date?: string;
+  search_mode?: 'hybrid' | 'keyword' | 'semantic';
+  similarity_threshold?: number;
 }
 
 export interface CreateConnectionArgs {
@@ -52,6 +54,19 @@ export interface ListMemoryLabelsArgs {
   // No arguments needed for this tool
 }
 
+export interface QueryMemoriesArgs {
+  cypher: string;
+  params?: Record<string, any>;
+}
+
+export interface MemoryStatsArgs {
+  // No arguments needed for this tool
+}
+
+export interface DreamArgs {
+  dry_run?: boolean;
+}
+
 export function isCreateMemoryArgs(args: unknown): args is CreateMemoryArgs {
   return typeof args === 'object' && args !== null && typeof (args as CreateMemoryArgs).label === 'string' && typeof (args as CreateMemoryArgs).properties === 'object';
 }
@@ -60,7 +75,13 @@ export function isSearchMemoriesArgs(args: unknown): args is SearchMemoriesArgs 
   if (typeof args !== 'object' || args === null) return false;
   const searchArgs = args as SearchMemoriesArgs;
   if (searchArgs.query !== undefined && typeof searchArgs.query !== 'string') return false;
+  if (searchArgs.label !== undefined && typeof searchArgs.label !== 'string') return false;
+  if (searchArgs.depth !== undefined && typeof searchArgs.depth !== 'number') return false;
+  if (searchArgs.order_by !== undefined && typeof searchArgs.order_by !== 'string') return false;
+  if (searchArgs.limit !== undefined && typeof searchArgs.limit !== 'number') return false;
   if (searchArgs.since_date !== undefined && typeof searchArgs.since_date !== 'string') return false;
+  if (searchArgs.search_mode !== undefined && !['hybrid', 'keyword', 'semantic'].includes(searchArgs.search_mode)) return false;
+  if (searchArgs.similarity_threshold !== undefined && typeof searchArgs.similarity_threshold !== 'number') return false;
   return true;
 }
 
@@ -113,6 +134,24 @@ export function isDeleteConnectionArgs(args: unknown): args is DeleteConnectionA
 }
 
 export function isListMemoryLabelsArgs(args: unknown): args is ListMemoryLabelsArgs {
-  // This tool doesn't require any arguments, so just check it's an object
   return typeof args === 'object' && args !== null;
+}
+
+export function isQueryMemoriesArgs(args: unknown): args is QueryMemoriesArgs {
+  if (typeof args !== 'object' || args === null) return false;
+  const queryArgs = args as QueryMemoriesArgs;
+  if (typeof queryArgs.cypher !== 'string') return false;
+  if (queryArgs.params !== undefined && (typeof queryArgs.params !== 'object' || queryArgs.params === null || Array.isArray(queryArgs.params))) return false;
+  return true;
+}
+
+export function isMemoryStatsArgs(args: unknown): args is MemoryStatsArgs {
+  return typeof args === 'object' && args !== null;
+}
+
+export function isDreamArgs(args: unknown): args is DreamArgs {
+  if (typeof args !== 'object' || args === null) return false;
+  const dreamArgs = args as DreamArgs;
+  if (dreamArgs.dry_run !== undefined && typeof dreamArgs.dry_run !== 'boolean') return false;
+  return true;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,21 @@ export interface DreamArgs {
   dry_run?: boolean;
 }
 
+/** Labels and relationship types are interpolated into Cypher, so they must be plain identifiers. */
+export const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+export function isIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && IDENTIFIER_RE.test(value);
+}
+
+/** Backtick-quote a validated identifier for use in Cypher. Throws on anything not validated. */
+export function cypherIdentifier(value: string): string {
+  if (!isIdentifier(value)) {
+    throw new Error(`Invalid Cypher identifier: ${JSON.stringify(value)}`);
+  }
+  return '`' + value + '`';
+}
+
 export const SEARCH_MAX_LIMIT = 200;
 export const SEARCH_MAX_DEPTH = 5;
 
@@ -82,8 +97,13 @@ function isIntegerInRange(value: unknown, min: number, max: number): boolean {
   return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max;
 }
 
+const isNodeId = (value: unknown): boolean => isIntegerInRange(value, 0, Number.MAX_SAFE_INTEGER);
+
 export function isCreateMemoryArgs(args: unknown): args is CreateMemoryArgs {
-  return typeof args === 'object' && args !== null && typeof (args as CreateMemoryArgs).label === 'string' && typeof (args as CreateMemoryArgs).properties === 'object';
+  return isPlainObject(args) &&
+    hasOnlyKeys(args, ['label', 'properties']) &&
+    isIdentifier(args.label) &&
+    isPlainObject(args.properties);
 }
 
 const SEARCH_KEYS = ['query', 'label', 'depth', 'order_by', 'limit', 'since_date', 'search_mode', 'similarity_threshold'] as const;
@@ -106,51 +126,40 @@ export function isSearchMemoriesArgs(args: unknown): args is SearchMemoriesArgs 
 }
 
 export function isCreateConnectionArgs(args: unknown): args is CreateConnectionArgs {
-  return (
-    typeof args === 'object' &&
-    args !== null &&
-    typeof (args as CreateConnectionArgs).fromMemoryId === 'number' &&
-    typeof (args as CreateConnectionArgs).toMemoryId === 'number' &&
-    typeof (args as CreateConnectionArgs).type === 'string'
-  );
+  return isPlainObject(args) &&
+    hasOnlyKeys(args, ['fromMemoryId', 'toMemoryId', 'type', 'properties']) &&
+    isNodeId(args.fromMemoryId) &&
+    isNodeId(args.toMemoryId) &&
+    isIdentifier(args.type) &&
+    (args.properties === undefined || isPlainObject(args.properties));
 }
 
 export function isUpdateMemoryArgs(args: unknown): args is UpdateMemoryArgs {
-  return (
-    typeof args === 'object' &&
-    args !== null &&
-    typeof (args as UpdateMemoryArgs).nodeId === 'number' &&
-    typeof (args as UpdateMemoryArgs).properties === 'object'
-  );
+  return isPlainObject(args) &&
+    hasOnlyKeys(args, ['nodeId', 'properties']) &&
+    isNodeId(args.nodeId) &&
+    isPlainObject(args.properties);
 }
 
 export function isUpdateConnectionArgs(args: unknown): args is UpdateConnectionArgs {
-  return (
-    typeof args === 'object' &&
-    args !== null &&
-    typeof (args as UpdateConnectionArgs).fromMemoryId === 'number' &&
-    typeof (args as UpdateConnectionArgs).toMemoryId === 'number' &&
-    typeof (args as UpdateConnectionArgs).type === 'string' &&
-    typeof (args as UpdateConnectionArgs).properties === 'object'
-  );
+  return isPlainObject(args) &&
+    hasOnlyKeys(args, ['fromMemoryId', 'toMemoryId', 'type', 'properties']) &&
+    isNodeId(args.fromMemoryId) &&
+    isNodeId(args.toMemoryId) &&
+    isIdentifier(args.type) &&
+    isPlainObject(args.properties);
 }
 
 export function isDeleteMemoryArgs(args: unknown): args is DeleteMemoryArgs {
-  return (
-    typeof args === 'object' &&
-    args !== null &&
-    typeof (args as DeleteMemoryArgs).nodeId === 'number'
-  );
+  return isPlainObject(args) && hasOnlyKeys(args, ['nodeId']) && isNodeId(args.nodeId);
 }
 
 export function isDeleteConnectionArgs(args: unknown): args is DeleteConnectionArgs {
-  return (
-    typeof args === 'object' &&
-    args !== null &&
-    typeof (args as DeleteConnectionArgs).fromMemoryId === 'number' &&
-    typeof (args as DeleteConnectionArgs).toMemoryId === 'number' &&
-    typeof (args as DeleteConnectionArgs).type === 'string'
-  );
+  return isPlainObject(args) &&
+    hasOnlyKeys(args, ['fromMemoryId', 'toMemoryId', 'type']) &&
+    isNodeId(args.fromMemoryId) &&
+    isNodeId(args.toMemoryId) &&
+    isIdentifier(args.type);
 }
 
 export function isListMemoryLabelsArgs(args: unknown): args is ListMemoryLabelsArgs {

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -44,6 +44,7 @@ const runNextTest = () => {
       console.log(`✅ ${testFile} completed successfully`);
     } else {
       console.log(`❌ ${testFile} failed with code ${code}`);
+      process.exitCode = 1;
     }
 
     currentTest += 1;

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -7,6 +7,8 @@ import { dirname, join } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const TEST_TIMEOUT_MS = 180000;
+
 const tests = [
   'test-embeddings-unit.js',
   'test-server-startup.js',
@@ -39,7 +41,15 @@ const runNextTest = () => {
     cwd: __dirname
   });
 
+  // A hung child (e.g. waiting on Neo4j) must not hang the suite.
+  const deadline = setTimeout(() => {
+    console.log(`⏰ ${testFile} exceeded ${TEST_TIMEOUT_MS / 1000}s; killing it`);
+    process.exitCode = 1;
+    testProcess.kill('SIGKILL');
+  }, TEST_TIMEOUT_MS);
+
   testProcess.on('close', (code) => {
+    clearTimeout(deadline);
     if (code === 0) {
       console.log(`✅ ${testFile} completed successfully`);
     } else {

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-// Master test script that runs all function tests in sequence
-// This ensures tests run in the correct order (create data first, then test updates)
-
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -11,9 +8,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const tests = [
+  'test-embeddings-unit.js',
   'test-server-startup.js',
   'test-create-memory.js',
   'test-search-memories.js',
+  'test-search-semantic.js',
   'test-search-arrays.js',
   'test-create-connection.js',
   'test-update-memory.js',
@@ -34,10 +33,10 @@ const runNextTest = () => {
 
   const testFile = tests[currentTest];
   console.log(`\n🚀 Running ${testFile}...`);
-  
+
   const testProcess = spawn('node', [join(__dirname, testFile)], {
     stdio: 'inherit',
-    cwd: __dirname // Run tests from the tests directory
+    cwd: __dirname
   });
 
   testProcess.on('close', (code) => {
@@ -46,9 +45,8 @@ const runNextTest = () => {
     } else {
       console.log(`❌ ${testFile} failed with code ${code}`);
     }
-    
-    currentTest++;
-    // Add small delay between tests
+
+    currentTest += 1;
     setTimeout(runNextTest, 1000);
   });
 };

--- a/tests/test-embeddings-unit.js
+++ b/tests/test-embeddings-unit.js
@@ -4,6 +4,9 @@ import assert from 'assert';
 import { cosine, createEmbedder, embeddingText, nameText, scrub } from '../build/embeddings.js';
 import { keywordMatches, rank } from '../build/search.js';
 import { contentKeys, factLikeKeys, maxProperties } from '../build/hygiene.js';
+import { readOnlyViolation } from '../build/cypher-guard.js';
+import { isDreamArgs, isMemoryStatsArgs, isQueryMemoriesArgs, isSearchMemoriesArgs } from '../build/types.js';
+import { secureEndpoint } from '../build/embeddings.js';
 
 function approxEqual(actual, expected, epsilon = 1e-9) {
   assert.ok(Math.abs(actual - expected) <= epsilon, `expected ${actual} ≈ ${expected}`);
@@ -106,6 +109,41 @@ try {
   assert.deepStrictEqual(factLikeKeys(bloated), ['live_call_camera_failure_2026_07_31', 'preference']);
   assert.strictEqual(maxProperties({}), 30);
   assert.strictEqual(maxProperties({ REVERIE_MAX_PROPERTIES: '12' }), 12);
+  assert.strictEqual(maxProperties({ REVERIE_MAX_PROPERTIES: '12.5' }), 30);
+  assert.strictEqual(maxProperties({ REVERIE_MAX_PROPERTIES: '12abc' }), 30);
+  assert.strictEqual(maxProperties({ REVERIE_MAX_PROPERTIES: '9999' }), 30);
+
+  // keyword matching ignores housekeeping fields such as created_at
+  assert.strictEqual(keywordMatches('2026', { name: 'Ben', created_at: '2026-01-01T00:00:00Z' }), false);
+
+  // read-only Cypher guard
+  assert.strictEqual(readOnlyViolation('MATCH (n:Person) RETURN n.name'), null);
+  assert.strictEqual(readOnlyViolation("MATCH (n) WHERE n.name = 'Sunset' RETURN n"), null);
+  assert.strictEqual(readOnlyViolation('CALL db.labels() YIELD label RETURN label'), null);
+  assert.ok(readOnlyViolation('MATCH (n) DETACH DELETE n'));
+  assert.ok(readOnlyViolation("CALL db.create.setNodeVectorProperty(n, 'embedding', [1.0])"));
+  assert.ok(readOnlyViolation("CALL apoc.create.node(['X'], {}) YIELD node RETURN node"));
+  assert.ok(readOnlyViolation('CALL { MATCH (n) RETURN n } RETURN 1'));
+
+  // argument validation rejects unknown keys and out-of-range numbers
+  assert.strictEqual(isSearchMemoriesArgs({ query: 'x', limit: 5, depth: 2, similarity_threshold: 0.5 }), true);
+  assert.strictEqual(isSearchMemoriesArgs({ query: 'x', search_mod: 'semantic' }), false);
+  assert.strictEqual(isSearchMemoriesArgs({ limit: -1 }), false);
+  assert.strictEqual(isSearchMemoriesArgs({ limit: 201 }), false);
+  assert.strictEqual(isSearchMemoriesArgs({ depth: 1.5 }), false);
+  assert.strictEqual(isSearchMemoriesArgs({ similarity_threshold: 1.2 }), false);
+  assert.strictEqual(isMemoryStatsArgs({}), true);
+  assert.strictEqual(isMemoryStatsArgs([]), false);
+  assert.strictEqual(isMemoryStatsArgs({ verbose: true }), false);
+  assert.strictEqual(isDreamArgs({ dry_run: true }), true);
+  assert.strictEqual(isDreamArgs({ dryRun: true }), false);
+  assert.strictEqual(isQueryMemoriesArgs({ cypher: 'RETURN 1', params: { a: 1 } }), true);
+  assert.strictEqual(isQueryMemoriesArgs({ cypher: 'RETURN 1', params: [1] }), false);
+
+  // provider endpoints must be https unless loopback
+  assert.strictEqual(secureEndpoint('https://api.openai.com/v1/', 'X'), 'https://api.openai.com/v1');
+  assert.strictEqual(secureEndpoint('http://localhost:8080/v1', 'X'), 'http://localhost:8080/v1');
+  assert.throws(() => secureEndpoint('http://proxy.example.com/v1', 'X'));
 
   console.log('PASS test-embeddings-unit: embeddings helpers and hybrid ranking behave as expected');
 } catch (error) {

--- a/tests/test-embeddings-unit.js
+++ b/tests/test-embeddings-unit.js
@@ -4,8 +4,9 @@ import assert from 'assert';
 import { cosine, createEmbedder, embeddingText, nameText, scrub } from '../build/embeddings.js';
 import { keywordMatches, rank } from '../build/search.js';
 import { contentKeys, factLikeKeys, maxProperties } from '../build/hygiene.js';
-import { readOnlyViolation } from '../build/cypher-guard.js';
-import { isDreamArgs, isMemoryStatsArgs, isQueryMemoriesArgs, isSearchMemoriesArgs } from '../build/types.js';
+import { readOnlyViolation, stripComments } from '../build/cypher-guard.js';
+import { cypherIdentifier, isCreateConnectionArgs, isCreateMemoryArgs, isDreamArgs, isMemoryStatsArgs, isQueryMemoriesArgs, isSearchMemoriesArgs } from '../build/types.js';
+import { lazyEmbedBatch } from '../build/hygiene.js';
 import { secureEndpoint } from '../build/embeddings.js';
 
 function approxEqual(actual, expected, epsilon = 1e-9) {
@@ -124,6 +125,28 @@ try {
   assert.ok(readOnlyViolation("CALL db.create.setNodeVectorProperty(n, 'embedding', [1.0])"));
   assert.ok(readOnlyViolation("CALL apoc.create.node(['X'], {}) YIELD node RETURN node"));
   assert.ok(readOnlyViolation('CALL { MATCH (n) RETURN n } RETURN 1'));
+  // comments cannot hide a procedure from the guard
+  assert.ok(readOnlyViolation("CALL /* hi */ apoc.load.json('http://169.254.169.254/') YIELD value RETURN value"));
+  assert.ok(readOnlyViolation("CALL // c\n apoc.create.node(['X'], {}) YIELD node RETURN node"));
+  assert.strictEqual(readOnlyViolation('CALL /* fine */ db.labels() YIELD label RETURN label'), null);
+  assert.strictEqual(stripComments('MATCH (n) // trailing\nRETURN n /* block */'), 'MATCH (n)  \nRETURN n  ');
+
+  // labels and relationship types are identifiers; anything else is rejected before it reaches Cypher
+  assert.strictEqual(isCreateMemoryArgs({ label: 'person', properties: { name: 'A' } }), true);
+  assert.strictEqual(isCreateMemoryArgs({ label: 'person) DETACH DELETE n //', properties: {} }), false);
+  assert.strictEqual(isCreateMemoryArgs({ label: 'person', properties: [] }), false);
+  assert.strictEqual(isCreateMemoryArgs({ label: 'person', properties: {}, extra: true }), false);
+  assert.strictEqual(isCreateConnectionArgs({ fromMemoryId: 1, toMemoryId: 2, type: 'WORKS_AT' }), true);
+  assert.strictEqual(isCreateConnectionArgs({ fromMemoryId: 1, toMemoryId: 2, type: 'X]->() DETACH DELETE' }), false);
+  assert.strictEqual(isCreateConnectionArgs({ fromMemoryId: 1.5, toMemoryId: 2, type: 'WORKS_AT' }), false);
+  assert.strictEqual(cypherIdentifier('Person'), '`Person`');
+  assert.throws(() => cypherIdentifier('Person`) DETACH DELETE n'));
+
+  assert.strictEqual(lazyEmbedBatch({}), 100);
+  assert.strictEqual(lazyEmbedBatch({ REVERIE_LAZY_EMBED_BATCH: '50' }), 50);
+  assert.strictEqual(lazyEmbedBatch({ REVERIE_LAZY_EMBED_BATCH: '50abc' }), 100);
+  assert.strictEqual(lazyEmbedBatch({ REVERIE_LAZY_EMBED_BATCH: '5000' }), 100);
+  assert.throws(() => secureEndpoint('http://ollama.example.com:11434', 'OLLAMA_HOST'));
 
   // argument validation rejects unknown keys and out-of-range numbers
   assert.strictEqual(isSearchMemoriesArgs({ query: 'x', limit: 5, depth: 2, similarity_threshold: 0.5 }), true);

--- a/tests/test-embeddings-unit.js
+++ b/tests/test-embeddings-unit.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import assert from 'assert';
+import { cosine, createEmbedder, embeddingText, nameText, scrub } from '../build/embeddings.js';
+import { keywordMatches, rank } from '../build/search.js';
+
+function approxEqual(actual, expected, epsilon = 1e-9) {
+  assert.ok(Math.abs(actual - expected) <= epsilon, `expected ${actual} ≈ ${expected}`);
+}
+
+try {
+  approxEqual(cosine([1, 0, 0], [1, 0, 0]), 1);
+  approxEqual(cosine([1, 0], [0, 1]), 0);
+
+  const text = embeddingText('Person', {
+    name: 'Ben Weeks',
+    aliases: ['Benjamin Weeks', 'B. Weeks'],
+    email: 'ben@example.com',
+    embedding: [1, 2, 3],
+    name_embedding: [1, 2, 3],
+    embedding_model: 'local/test',
+    embedded_at: '2026-01-01T00:00:00.000Z',
+    created_at: '2026-01-01T00:00:00.000Z'
+  });
+  assert.ok(text.startsWith('Person: Ben Weeks'));
+  assert.ok(text.includes('aliases: Benjamin Weeks, B. Weeks'));
+  assert.ok(text.includes('email: ben@example.com'));
+  assert.ok(!text.includes('embedding:'));
+  assert.ok(!text.includes('created_at:'));
+
+  const scrubbed = scrub({
+    embedding: [1, 2, 3],
+    nested: {
+      embedding_model: 'local/test',
+      embedded_at: '2026-01-01T00:00:00.000Z',
+      keep: true
+    },
+    items: [
+      { embedding: [9, 9, 9], value: 'a' },
+      { value: 'b', child: { embedding_model: 'x', keep: 2 } }
+    ]
+  });
+  assert.deepStrictEqual(scrubbed, {
+    nested: { keep: true },
+    items: [
+      { value: 'a' },
+      { value: 'b', child: { keep: 2 } }
+    ]
+  });
+
+  assert.strictEqual(createEmbedder({ REVERIE_EMBEDDINGS: 'none' }), null);
+
+  const ranked = rank(
+    [
+      {
+        id: 1,
+        props: {
+          name: 'Benjamin Weeks',
+          created_at: '2026-01-03T00:00:00.000Z'
+        }
+      },
+      {
+        id: 2,
+        props: {
+          name: 'Will Example',
+          created_at: '2026-01-02T00:00:00.000Z',
+          embedding: [0, 1, 0],
+          name_embedding: [0.8, 0.6, 0],
+          embedding_model: 'local/demo'
+        }
+      },
+      {
+        id: 3,
+        props: {
+          name: 'Far Match',
+          created_at: '2026-01-01T00:00:00.000Z',
+          embedding: [0, 1, 0],
+          embedding_model: 'local/demo'
+        }
+      }
+    ],
+    {
+      query: 'Ben Weeks',
+      mode: 'hybrid',
+      queryEmbedding: [1, 0, 0],
+      threshold: 0.4,
+      modelId: 'local/demo'
+    }
+  );
+  assert.deepStrictEqual(ranked.map((item) => item.id), [1, 2]);
+  assert.deepStrictEqual(ranked.map((item) => item.match), ['keyword', 'semantic']);
+  approxEqual(ranked[1].score, 0.8); // best of embedding (0) and name_embedding (0.8)
+
+  assert.strictEqual(nameText('Person', { name: 'Ben Weeks', aliases: ['Benjamin'], context: 'ignored' }), 'Person: Ben Weeks\naliases: Benjamin');
+
+  assert.strictEqual(keywordMatches('Ben Weeks', { name: 'Benjamin' }), true);
+  assert.strictEqual(keywordMatches('Benjamin', { name: 'Ben' }), false);
+
+  console.log('PASS test-embeddings-unit: embeddings helpers and hybrid ranking behave as expected');
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/tests/test-embeddings-unit.js
+++ b/tests/test-embeddings-unit.js
@@ -13,7 +13,7 @@ function approxEqual(actual, expected, epsilon = 1e-9) {
   assert.ok(Math.abs(actual - expected) <= epsilon, `expected ${actual} ≈ ${expected}`);
 }
 
-try {
+(async () => { try {
   approxEqual(cosine([1, 0, 0], [1, 0, 0]), 1);
   approxEqual(cosine([1, 0], [0, 1]), 0);
 
@@ -163,6 +163,21 @@ try {
   assert.strictEqual(isQueryMemoriesArgs({ cypher: 'RETURN 1', params: { a: 1 } }), true);
   assert.strictEqual(isQueryMemoriesArgs({ cypher: 'RETURN 1', params: [1] }), false);
 
+  // a provider that returns fewer vectors than inputs must fail loudly, not shift later pairs
+  {
+    const realFetch = globalThis.fetch;
+    const reply = (body) => async () => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+    globalThis.fetch = reply({ data: [{ index: 0, embedding: [1, 0] }] });
+    try {
+      const embedder = createEmbedder({ REVERIE_EMBEDDINGS: 'openai', OPENAI_API_KEY: 'test' });
+      await assert.rejects(embedder.embed(['a', 'b']), /returned 1 vectors for 2 inputs/);
+      globalThis.fetch = reply({ data: [{ index: 1, embedding: [0, 1] }, { index: 0, embedding: [1, 0] }] });
+      assert.deepStrictEqual(await embedder.embed(['a', 'b']), [[1, 0], [0, 1]], 'out-of-order indices are honoured');
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  }
+
   // provider endpoints must be https unless loopback
   assert.strictEqual(secureEndpoint('https://api.openai.com/v1/', 'X'), 'https://api.openai.com/v1');
   assert.strictEqual(secureEndpoint('http://localhost:8080/v1', 'X'), 'http://localhost:8080/v1');
@@ -172,4 +187,4 @@ try {
 } catch (error) {
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);
-}
+} })();

--- a/tests/test-embeddings-unit.js
+++ b/tests/test-embeddings-unit.js
@@ -3,6 +3,7 @@
 import assert from 'assert';
 import { cosine, createEmbedder, embeddingText, nameText, scrub } from '../build/embeddings.js';
 import { keywordMatches, rank } from '../build/search.js';
+import { contentKeys, factLikeKeys, maxProperties } from '../build/hygiene.js';
 
 function approxEqual(actual, expected, epsilon = 1e-9) {
   assert.ok(Math.abs(actual - expected) <= epsilon, `expected ${actual} ≈ ${expected}`);
@@ -95,6 +96,16 @@ try {
 
   assert.strictEqual(keywordMatches('Ben Weeks', { name: 'Benjamin' }), true);
   assert.strictEqual(keywordMatches('Benjamin', { name: 'Ben' }), false);
+
+  const bloated = {
+    name: 'Ben Weeks', email: 'ben@example.com', _id: 1, _labels: ['Person'], created_at: 'x', embedding: [1],
+    live_call_camera_failure_2026_07_31: 'short', role: 'Founder',
+    preference: 'A very long piece of prose that is clearly an episode rather than an attribute of the person, well over the limit for a plain attribute value.'
+  };
+  assert.deepStrictEqual(contentKeys(bloated), ['name', 'email', 'live_call_camera_failure_2026_07_31', 'role', 'preference']);
+  assert.deepStrictEqual(factLikeKeys(bloated), ['live_call_camera_failure_2026_07_31', 'preference']);
+  assert.strictEqual(maxProperties({}), 30);
+  assert.strictEqual(maxProperties({ REVERIE_MAX_PROPERTIES: '12' }), 12);
 
   console.log('PASS test-embeddings-unit: embeddings helpers and hybrid ranking behave as expected');
 } catch (error) {

--- a/tests/test-get-guidance.js
+++ b/tests/test-get-guidance.js
@@ -51,7 +51,7 @@ const testGetGuidance = () => {
                 break;
                 
               case 2: // Labels only
-                if (content && content.includes('person, place, organization')) {
+                if (content && content.includes('People & Living Things')) {
                   console.log('✅ Labels guidance test passed');
                   testsPassed++;
                 } else {
@@ -60,7 +60,7 @@ const testGetGuidance = () => {
                 break;
                 
               case 3: // Relationships only
-                if (content && content.includes('KNOWS, FRIENDS_WITH')) {
+                if (content && content.includes('Personal Relationships')) {
                   console.log('✅ Relationships guidance test passed');
                   testsPassed++;
                 } else {
@@ -69,7 +69,7 @@ const testGetGuidance = () => {
                 break;
                 
               case 4: // Best practices
-                if (content && content.includes('Use lowercase for labels')) {
+                if (content && content.includes('ALWAYS SEARCH FIRST')) {
                   console.log('✅ Best practices guidance test passed');
                   testsPassed++;
                 } else {

--- a/tests/test-search-memories.js
+++ b/tests/test-search-memories.js
@@ -87,7 +87,7 @@ const testSearchMemories = () => {
         name: 'search_memories',
         arguments: {
           query: test.query,
-          type: test.type,
+          label: test.type,
           depth: test.depth,
           limit: test.limit
         }

--- a/tests/test-search-semantic.js
+++ b/tests/test-search-semantic.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '../.env' });
+
+const testSearchSemantic = () => {
+  console.log('🧠🔍 Testing semantic search_memories mode...');
+
+  const mcp = spawn('node', ['../build/index.js'], {
+    env: { ...process.env },
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  let messageId = 1;
+  let outputBuffer = '';
+  let memoryId = null;
+
+  const sendMessage = (name, args) => {
+    const message = {
+      jsonrpc: '2.0',
+      id: messageId++,
+      method: 'tools/call',
+      params: { name, arguments: args }
+    };
+    mcp.stdin.write(JSON.stringify(message) + '\n');
+  };
+
+  mcp.stdout.on('data', (data) => {
+    outputBuffer += data.toString();
+    const lines = outputBuffer.split('\n');
+    outputBuffer = lines[lines.length - 1];
+
+    for (let index = 0; index < lines.length - 1; index += 1) {
+      const line = lines[index];
+      if (!line.trim()) {
+        continue;
+      }
+
+      try {
+        const response = JSON.parse(line);
+
+        if (response.id === 1) {
+          const content = response.result?.content?.[0]?.text;
+          if (!content) {
+            continue;
+          }
+
+          const result = JSON.parse(content);
+          memoryId = result.memory?._id ?? result.n?._id ?? null;
+          if (memoryId === null) {
+            throw new Error('Failed to capture created memory ID');
+          }
+
+          console.log(`✅ Created test memory with ID: ${memoryId}`);
+          sendMessage('search_memories', {
+            query: 'Ben Weeks',
+            label: 'person',
+            search_mode: 'semantic',
+            similarity_threshold: 0.3,
+            depth: 0,
+            limit: 5
+          });
+        } else if (response.id === 2) {
+          const content = response.result?.content?.[0]?.text;
+          const result = content ? JSON.parse(content) : [];
+          const hit = Array.isArray(result)
+            ? result.find((row) => row?.memory?.name === 'Benjamin Weeks')
+            : null;
+
+          if (!hit) {
+            throw new Error('Expected semantic search to return Benjamin Weeks');
+          }
+
+          console.log('✅ semantic search_memories test passed');
+          sendMessage('delete_memory', { nodeId: memoryId });
+        } else if (response.id === 3) {
+          console.log('🧹 Cleaned up semantic search test memory');
+          clearTimeout(timeout);
+          mcp.kill();
+          process.exit(0);
+        }
+      } catch (error) {
+        console.error('❌ Error:', error instanceof Error ? error.message : error);
+        mcp.kill();
+        process.exit(1);
+      }
+    }
+  });
+
+  mcp.stderr.on('data', (data) => {
+    console.error('❌ Error:', data.toString());
+  });
+
+  sendMessage('create_memory', {
+    label: 'person',
+    properties: {
+      name: 'Benjamin Weeks',
+      context: 'Semantic search integration test',
+      created_at: new Date().toISOString()
+    }
+  });
+
+  const timeout = setTimeout(() => {
+    console.log('⏰ Test timeout');
+    mcp.kill();
+    process.exit(1);
+  }, 60000); // first run may download the local embedding model
+};
+
+testSearchSemantic();

--- a/tests/test-search-semantic.js
+++ b/tests/test-search-semantic.js
@@ -28,26 +28,35 @@ const testSearchSemantic = () => {
     mcp.stdin.write(JSON.stringify(message) + '\n');
   };
 
-  // Every exit path comes through here so the test node is always deleted (bounded by a 3s backstop).
+  // Every exit path comes through here: delete the test node, confirm the deletion, then wait for the
+  // child to close. A 3s backstop bounds each stage so a hung server cannot leave the test running.
+  let deleteId = null;
+  let exitCode = 0;
   const finish = (code) => {
     if (finishing) return;
     finishing = true;
+    exitCode = code;
     clearTimeout(timeout);
-    const exit = () => {
-      mcp.kill();
-      process.exit(code);
-    };
     if (memoryId === null) {
-      exit();
+      terminate();
       return;
     }
-    const backstop = setTimeout(exit, 3000);
-    mcp.stdout.once('data', () => {
-      clearTimeout(backstop);
-      console.log('🧹 Cleaned up semantic search test memory');
-      exit();
-    });
+    deleteId = messageId;
     sendMessage('delete_memory', { nodeId: memoryId });
+    setTimeout(() => {
+      console.error('❌ Error: delete_memory did not respond; the test node may be left behind');
+      exitCode = 1;
+      terminate();
+    }, 3000).unref();
+  };
+
+  const terminate = () => {
+    const backstop = setTimeout(() => process.exit(exitCode || 1), 3000);
+    mcp.once('close', () => {
+      clearTimeout(backstop);
+      process.exit(exitCode);
+    });
+    mcp.kill();
   };
 
   const timeout = setTimeout(() => {
@@ -56,7 +65,6 @@ const testSearchSemantic = () => {
   }, 60000); // first run may download the local embedding model
 
   mcp.stdout.on('data', (data) => {
-    if (finishing) return;
     outputBuffer += data.toString();
     const lines = outputBuffer.split('\n');
     outputBuffer = lines[lines.length - 1];
@@ -67,6 +75,19 @@ const testSearchSemantic = () => {
 
       try {
         const response = JSON.parse(line);
+
+        if (finishing) {
+          if (response.id === deleteId) {
+            if (response.error || response.result?.isError) {
+              console.error('❌ Error: delete_memory failed:', JSON.stringify(response.error ?? response.result));
+              exitCode = 1;
+            } else {
+              console.log('🧹 Cleaned up semantic search test memory');
+            }
+            terminate();
+          }
+          continue;
+        }
 
         if (response.id === 1) {
           const content = response.result?.content?.[0]?.text;
@@ -96,6 +117,11 @@ const testSearchSemantic = () => {
 
           if (!hit) {
             throw new Error('Expected semantic search to return the Benjamin Weeks test node');
+          }
+          // In semantic mode the keyword tier is not used, so _match proves the embedding path ran
+          // rather than the keyword fallback that kicks in when embeddings are unavailable.
+          if (hit.memory._match !== 'semantic') {
+            throw new Error(`Expected a semantic match, got _match=${hit.memory._match}`);
           }
 
           console.log('✅ semantic search_memories test passed');

--- a/tests/test-search-semantic.js
+++ b/tests/test-search-semantic.js
@@ -16,6 +16,7 @@ const testSearchSemantic = () => {
   let messageId = 1;
   let outputBuffer = '';
   let memoryId = null;
+  let finishing = false;
 
   const sendMessage = (name, args) => {
     const message = {
@@ -27,28 +28,52 @@ const testSearchSemantic = () => {
     mcp.stdin.write(JSON.stringify(message) + '\n');
   };
 
+  // Every exit path comes through here so the test node is always deleted (bounded by a 3s backstop).
+  const finish = (code) => {
+    if (finishing) return;
+    finishing = true;
+    clearTimeout(timeout);
+    const exit = () => {
+      mcp.kill();
+      process.exit(code);
+    };
+    if (memoryId === null) {
+      exit();
+      return;
+    }
+    const backstop = setTimeout(exit, 3000);
+    mcp.stdout.once('data', () => {
+      clearTimeout(backstop);
+      console.log('🧹 Cleaned up semantic search test memory');
+      exit();
+    });
+    sendMessage('delete_memory', { nodeId: memoryId });
+  };
+
+  const timeout = setTimeout(() => {
+    console.log('⏰ Test timeout');
+    finish(1);
+  }, 60000); // first run may download the local embedding model
+
   mcp.stdout.on('data', (data) => {
+    if (finishing) return;
     outputBuffer += data.toString();
     const lines = outputBuffer.split('\n');
     outputBuffer = lines[lines.length - 1];
 
     for (let index = 0; index < lines.length - 1; index += 1) {
       const line = lines[index];
-      if (!line.trim()) {
-        continue;
-      }
+      if (!line.trim()) continue;
 
       try {
         const response = JSON.parse(line);
 
         if (response.id === 1) {
           const content = response.result?.content?.[0]?.text;
-          if (!content) {
-            continue;
-          }
+          if (!content) continue;
 
           const result = JSON.parse(content);
-          memoryId = result.memory?._id ?? result.n?._id ?? null;
+          memoryId = result.memory?._id ?? null;
           if (memoryId === null) {
             throw new Error('Failed to capture created memory ID');
           }
@@ -66,31 +91,26 @@ const testSearchSemantic = () => {
           const content = response.result?.content?.[0]?.text;
           const result = content ? JSON.parse(content) : [];
           const hit = Array.isArray(result)
-            ? result.find((row) => row?.memory?.name === 'Benjamin Weeks')
+            ? result.find((row) => row?.memory?._id === memoryId)
             : null;
 
           if (!hit) {
-            throw new Error('Expected semantic search to return Benjamin Weeks');
+            throw new Error('Expected semantic search to return the Benjamin Weeks test node');
           }
 
           console.log('✅ semantic search_memories test passed');
-          sendMessage('delete_memory', { nodeId: memoryId });
-        } else if (response.id === 3) {
-          console.log('🧹 Cleaned up semantic search test memory');
-          clearTimeout(timeout);
-          mcp.kill();
-          process.exit(0);
+          finish(0);
         }
       } catch (error) {
         console.error('❌ Error:', error instanceof Error ? error.message : error);
-        mcp.kill();
-        process.exit(1);
+        finish(1);
       }
     }
   });
 
   mcp.stderr.on('data', (data) => {
-    console.error('❌ Error:', data.toString());
+    const text = data.toString();
+    if (!text.includes('running on stdio')) console.error('❌ Error:', text);
   });
 
   sendMessage('create_memory', {
@@ -101,12 +121,6 @@ const testSearchSemantic = () => {
       created_at: new Date().toISOString()
     }
   });
-
-  const timeout = setTimeout(() => {
-    console.log('⏰ Test timeout');
-    mcp.kill();
-    process.exit(1);
-  }, 60000); // first run may download the local embedding model
 };
 
 testSearchSemantic();


### PR DESCRIPTION
## Summary

Fixes the search gap in #2: substring matching meant "Benjamin" never found "Ben" and nothing handled name variants, synonyms or typos.

- **Hybrid search.** `search_memories` ranks a keyword tier (today's any-word substring match, score 1) above a semantic tier. New args `search_mode` (`hybrid` default | `keyword` | `semantic`) and `similarity_threshold` (default 0.4). Results carry `_score` and `_match`.
- **Two vectors per node.** `embedding` covers the full text, `name_embedding` only label, name and aliases; the score is the better of the two. Measured with MiniLM: "Ben Weeks" vs `person: Benjamin Weeks` scores 0.72, but 0.26 once a one-line context is mixed in, while unrelated names stay at or below 0.30. Cosine runs in JS, so no Neo4j vector index or GDS is required.
- **Pluggable embeddings, no key by default.** `REVERIE_EMBEDDINGS=local` (MiniLM via `@huggingface/transformers`, ~23 MB first-use download) | `openai` | `azure` | `ollama` | `voyage` | `none`. Nodes record `embedding_model`; changing provider re-embeds lazily on search or eagerly in `dream`. Any embedding failure degrades that call to keyword search. Embedding fields are scrubbed from every tool result.
- **Three new tools** so the Hermes plugin can become a thin client of this server: `query_memories` (read-only Cypher; blocks write clauses and any `CALL` outside `db.`/`dbms.`), `memory_stats`, `dream` (relabel lowercase labels, APOC merge of case-duplicate names, re-embed, orphan count; `dry_run`).
- The `label` filter is now case-insensitive so lowercase (this server's convention) and Capitalised (Hermes plugin) labels coexist.
- Version 0.4.0, `npm test` / `npm run test:unit` scripts, README sections for Search and Embeddings.

Supersedes #13, which GitHub closed when its base branch was deleted after #11 merged; rebased onto main.

## Test plan

- [x] `npm run build`, `npm run test:unit` (no network, no Neo4j)
- [x] Full suite against a throwaway `neo4j:5-community` + APOC container: all existing tests unchanged (`test-search-arrays` fails as before, it expects a `mcp-test` database); new `test-search-semantic` passes
- [x] Live: `dream` dry-run and real run relabelled 16 nodes and merged 2 duplicates via APOC on Neo4j 5.26; `query_memories` rejected `DETACH DELETE` and `apoc.create.node`; lowercase `label: person` matched `Person` nodes
- [ ] Deploy to Poppie/Sallie and run `dream` once to backfill embeddings

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds hybrid, keyword, and semantic memory search with pluggable embedding providers. It also adds read-only query, statistics, and graph-maintenance tools, with validation, fallback behaviour, and documentation.

## Worth a look

- **Design:** Review `src/search.ts:rank` for hybrid scoring, thresholds, and deterministic tie-breaking.
- **Risky change:** Review duplicate merging in `src/handlers/index.ts`. Confirm identity conflicts cannot merge distinct entities.
- **Security:** Review `src/cypher-guard.ts` and `Neo4jClient.executeReadQuery`. Confirm comment handling, procedure allow-listing, and limits block unsafe or costly queries.
- **Operational risk:** Review `src/embeddings.ts:createEmbedder` and provider request handling. Confirm endpoint validation, credential checks, timeouts, and keyword fallback are safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
