### PR TITLE
docs: first security email carries no details, requests a key

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,10 @@ report anything you find, and please do it privately.
 - Preferred: use GitHub's private vulnerability reporting on this repository
   (**Security → Report a vulnerability**). It creates a proposed advisory that only you and the
   repository's security managers can see.
-- Otherwise: email **support@knowall.ai**. If you need to encrypt, say so in a first message and
-  we will send a key.
+- Otherwise: email **support@knowall.ai** with the subject line `Security: mcp-reverie`.
+  **Put no vulnerability details in the first message.** Say only that you have a security
+  report and ask for an encryption key; we will reply with a PGP public key and a named contact,
+  and you send the details encrypted.
 
 Include what you can: the version or commit, the component (MCP server, Hermes plugin, brain
 API, Dreaming), steps to reproduce, and the impact you believe it has. A minimal proof of concept


### PR DESCRIPTION
## Summary

Follow-up to #15, mirroring a CodeRabbit point raised on the hermes-reverie copy: reporters using the email channel are told to put no vulnerability details in the first message and to request an encryption key, and to use a recognisable subject line.

## Test plan

N/A — documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This documentation-only PR updates `SECURITY.md` to improve security report handling. Reporters must omit vulnerability details from the first email, request a PGP key, and use a recognisable subject line.

### Worth a look
- `SECURITY.md`: Confirm that the first-contact process clearly separates the initial email from the later encrypted report.
- `SECURITY.md`: Confirm that the named contact can provide the requested encryption key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->