### PR TITLE
ci: release workflow publishes to npm and GHCR on a version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
           images: ghcr.io/knowall-ai/mcp-reverie
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+# Publishes a tagged version: `git tag v0.4.0 && git push origin v0.4.0`.
+# - npm: @knowall-ai/reverie with provenance (needs the NPM_TOKEN secret, an npm automation token)
+# - GHCR: ghcr.io/knowall-ai/mcp-reverie:<version> and :latest (uses the built-in GITHUB_TOKEN)
+# Smithery redeploys from the repository on its own schedule; trigger a redeploy from the
+# Smithery dashboard after a release if the listing lags.
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:unit
+      - name: Tag must match package.json version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag v$tag does not match package.json version $version"; exit 1
+          fi
+
+  npm:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # npm provenance
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  docker:
+    name: Publish container image
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/knowall-ai/mcp-reverie
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

Continuous delivery for the server. Pushing a tag `vX.Y.Z` that matches `package.json`:

1. **Verify**: build, unit tests, and a check that the tag equals the package version.
2. **npm**: `npm publish --access public --provenance` as `@knowall-ai/reverie`. Needs an npm **automation** token stored as the `NPM_TOKEN` repository secret (Settings → Secrets → Actions).
3. **Container**: builds the Dockerfile and pushes `ghcr.io/knowall-ai/mcp-reverie:<version>` and `:latest` using the built-in token.

Smithery pulls from the repository itself; after a release, trigger a redeploy from its dashboard if the listing lags. Once `@knowall-ai/reverie` is on npm, run `npm deprecate @knowall-ai/mcp-neo4j-agent-memory "Renamed to @knowall-ai/reverie"` (manual, needs npm login).

## Test plan

N/A — CI configuration. First real run: after #16 merges, bump to 0.4.0 and push `v0.4.0`; expect the three jobs green, the package visible on npm with a provenance badge, and the image on GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a GitHub Actions workflow for tagged releases. It builds and tests the project, verifies the tag against `package.json`, publishes the npm package with provenance, and pushes versioned and `latest` images to GHCR.

## Worth a look

- `.github/workflows/release.yml`: Confirm that `NPM_TOKEN` has the required scope and that workflow permissions are limited to publishing needs.
- `.github/workflows/release.yml`: Check that tag validation removes the `v` prefix and blocks publishing from an incorrect tag.
- `.github/workflows/release.yml`: Confirm that Docker image tagging and `latest` updates are safe for every version tag.
- `.github/workflows/release.yml`: Manual Smithery redeployment and npm deprecation remain release follow-up tasks, not automated workflow actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->