### PR TITLE
fix: exact search, archived hidden by default, relationship endpoints, string-aware Cypher guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ This approach makes the system more powerful and adaptable, as improvements in L
 - `hybrid` (default): keyword hits score `1`, then semantic matches add close variants such as `Benjamin Weeks` for `Ben Weeks`
 - `keyword`: any word of the query as a substring of any searchable content property (timestamps, `status` and embedding fields are never matched)
 - `semantic`: uses embeddings only when available, with graceful fallback to keyword behavior if embeddings are unavailable
+- `exact`: case-insensitive equality on `name`, `aliases` or `email`; the precise lookup to run before creating a memory, so "ben weeks" finds exactly "Ben Weeks" and nothing else
 
-Use `similarity_threshold` (default `0.4`, clamped to `0..1`) to control how strict semantic matches are. Results include `_score` and `_match` on each returned `memory` object so callers can explain why a memory was returned.
+Archived memories (`status = 'archived'`) are left out of results and of `list_memory_labels` unless `include_archived: true` is passed. Returned relationships carry `_start` and `_end` node ids, so a connection's direction is always recoverable.
+
+Use `similarity_threshold` (default `0.4`; must be between `0` and `1`, other values are rejected) to control how strict semantic matches are. Results include `_score` and `_match` on each returned `memory` object so callers can explain why a memory was returned.
 
 ### Neo4j Enterprise Support
 
@@ -92,7 +95,7 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
   - Filter by memory type (case-insensitive, so `person` and `Person` both work), date, depth, result limit, and sort order
 
 - `create_memory`: Create a new memory in the knowledge graph
-  - Flexible type system - use any label in lowercase (person, place, project, skill, etc.)
+  - Flexible type system - any label that is a plain identifier; Capitalised singular is canonical (Person, Place, Project, Skill…), and `dream` canonicalises lowercase labels
   - Store any properties as key-value pairs
   - Automatic timestamps for temporal tracking
 
@@ -424,9 +427,9 @@ Here are the events you attended last month:
 
 The system doesn't enforce strict types - you can create any type of memory that makes sense:
 
-**Common Types** (lowercase): person, place, organization, project, event, topic, object, animal, plant, food, activity, media, skill, document, meeting, task, habit, health, vehicle, tool, idea, goal
+**Common Types** (Capitalised singular is canonical; lowercase is accepted and canonicalised by `dream`): person, place, organization, project, event, topic, object, animal, plant, food, activity, media, skill, document, meeting, task, habit, health, vehicle, tool, idea, goal
 
-**But you can use any type** (lowercase): recipe, dream, memory, quote, book, movie, emotion, relationship, appointment, medication, exercise, symptom, payment, contract, etc.
+**But you can use any type** (any plain identifier): recipe, dream, memory, quote, book, movie, emotion, relationship, appointment, medication, exercise, symptom, payment, contract, etc.
 
 The LLM will intelligently reuse existing types when appropriate to maintain consistency.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@knowall-ai/reverie",
   "version": "0.4.0",
-  "description": "Reverie — graph memory that dreams. Graph-based memory system for AI agents. Store people, places, organizations as nodes. Build semantic relationships (KNOWS, WORKS_AT, CREATED). Hybrid keyword + semantic search finds partial matches and close variants. Filter by date, traverse relationships, maintain temporal context. Simple tools, LLM handles complexity. 13 tools for complete memory management.",
+  "description": "Reverie — graph memory that dreams. Graph-based memory system for AI agents. Store people, places, organizations as nodes. Build semantic relationships (KNOWS, WORKS_AT, CREATED). Hybrid keyword + semantic search finds partial matches and close variants. Filter by date, traverse relationships, maintain temporal context. Simple tools, LLM handles complexity. 12 tools for complete memory management.",
   "type": "module",
   "module": "./src/index.ts",
   "bin": {

--- a/src/cypher-guard.ts
+++ b/src/cypher-guard.ts
@@ -18,9 +18,51 @@ export const READ_ONLY_PROCEDURES = new Set<string>([
   'db.index.fulltext.queryrelationships'
 ]);
 
-/** Remove line and block comments so nothing can hide between a keyword and what follows it. */
+/**
+ * Reduce Cypher to the text the guard should look at: comments become spaces, and the contents of
+ * string literals and backtick-quoted identifiers are blanked so a `//` or a keyword inside a
+ * string can neither hide code nor trigger a false positive. A small stateful scan, not a regex,
+ * because a `//` inside a quoted URL must not be treated as a comment.
+ */
 export function stripComments(cypher: string): string {
-  return cypher.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+  let out = '';
+  let i = 0;
+  const n = cypher.length;
+  while (i < n) {
+    const ch = cypher[i];
+    const next = cypher[i + 1];
+    if (ch === '/' && next === '/') {
+      while (i < n && cypher[i] !== '\n') i++;
+      out += ' ';
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const end = cypher.indexOf('*/', i + 2);
+      i = end === -1 ? n : end + 2;
+      out += ' ';
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      out += quote;
+      i++;
+      while (i < n) {
+        const c = cypher[i];
+        if (c === '\\' && quote !== '`') { i += 2; continue; }      // escaped char inside a string
+        if (c === quote) {
+          if (cypher[i + 1] === quote) { i += 2; continue; }         // doubled quote
+          break;
+        }
+        i++;
+      }
+      out += quote;                                                   // literal contents dropped
+      i++;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
 }
 
 /** Returns why the Cypher is not read-only, or null when it passes the guard. */

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -92,6 +92,10 @@ export async function handleToolCall(
         const conditions: string[] = [];
         const queryParams: Record<string, any> = {};
 
+        if (!args.include_archived) {
+          conditions.push("coalesce(memory.status, '') <> 'archived'");
+        }
+
         if (args.label) {
           conditions.push('toLower(labels(memory)[0]) = toLower($label)');
           queryParams.label = args.label;
@@ -107,7 +111,7 @@ export async function handleToolCall(
         }
 
         // Keyword mode never needs the stored vectors, so leave them out of the wire payload.
-        const propsProjection = requestedMode === 'keyword'
+        const propsProjection = requestedMode === 'keyword' || requestedMode === 'exact'
           ? 'memory {.*, embedding: null, name_embedding: null}'
           : 'properties(memory)';
         baseQuery += ` RETURN id(memory) AS id, labels(memory)[0] AS label, ${propsProjection} AS props ORDER BY id(memory)`;
@@ -238,6 +242,7 @@ export async function handleToolCall(
 
         const query = `
           MATCH (memory)
+          WHERE $includeArchived OR coalesce(memory.status, '') <> 'archived'
           WITH labels(memory) AS nodeLabels
           UNWIND nodeLabels AS label
           WITH label, count(*) AS count
@@ -245,7 +250,7 @@ export async function handleToolCall(
           RETURN collect({label: label, count: count}) AS labels, sum(count) AS totalMemories
         `;
 
-        const result = await neo4jClient.executeQuery(query, {});
+        const result = await neo4jClient.executeQuery(query, { includeArchived: Boolean(args.include_archived) });
         return jsonResult(result);
       }
 
@@ -355,7 +360,7 @@ export async function handleToolCall(
             const [countRow] = await neo4jClient.executeQuery<{ count: number }>(
               `MATCH (n:\`${escapedSource}\`)
                REMOVE n:\`${escapedSource}\`
-               SET n:\`${escapedTarget}\`
+               SET n:\`${escapedTarget}\`, n.embedding_model = null
                RETURN count(n) AS count`
             );
             relabelled += countRow?.count ?? 0;
@@ -567,7 +572,7 @@ async function rankCandidates(
   let effectiveMode = requestedMode;
   let queryEmbedding: number[] | undefined;
 
-  if (trimmedQuery && requestedMode !== 'keyword') {
+  if (trimmedQuery && requestedMode !== 'keyword' && requestedMode !== 'exact') {
     if (!embedder) {
       effectiveMode = 'keyword';
     } else {

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -130,7 +130,7 @@ export async function handleToolCall(
           return jsonResult([]);
         }
 
-        const result = await fetchMemories(neo4jClient, rankedIds, depth, orderBy, limit);
+        const result = await fetchMemories(neo4jClient, rankedIds, depth, orderBy, limit, Boolean(args.include_archived));
         const scoring = new Map<number, { score: number; match: Ranked['match'] }>(
           topRanked.map((item) => [item.id, { score: Number(item.score.toFixed(2)), match: item.match }])
         );
@@ -674,7 +674,8 @@ async function fetchMemories(
   memoryIds: number[],
   depth: number,
   orderBy: string,
-  limit: number
+  limit: number,
+  includeArchived: boolean
 ): Promise<Record<string, any>[]> {
   let finalQuery = `
     MATCH (memory)
@@ -682,8 +683,10 @@ async function fetchMemories(
   `;
 
   if (depth > 0) {
+    // Archived nodes are hidden from the neighbourhood too, and a path through one is not followed.
     finalQuery += `
       OPTIONAL MATCH path = (memory)-[*1..${depth}]-(related)
+      WHERE $includeArchived OR all(x IN nodes(path) WHERE coalesce(x.status, '') <> 'archived')
       RETURN memory, collect(DISTINCT {
         memory: related,
         relationship: relationships(path)[0],
@@ -700,7 +703,7 @@ async function fetchMemories(
     `;
   }
 
-  return neo4jClient.executeQuery(finalQuery, { memoryIds });
+  return neo4jClient.executeQuery(finalQuery, { memoryIds, includeArchived });
 }
 
 interface DuplicateGroupReport {

--- a/src/neo4j-client.ts
+++ b/src/neo4j-client.ts
@@ -1,6 +1,19 @@
 import { cypherIdentifier } from './types.js';
 import neo4j, { Driver, Integer, Node, QueryResult, Record as Neo4jRecord, Relationship, Session } from 'neo4j-driver';
 
+const CLOSE_TIMEOUT_MS = 5_000;
+
+/** session.close() awaits connection release with no deadline; a stuck release must not hang a tool call. */
+async function closeBounded(session: Session): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<void>((resolve) => { timer = setTimeout(resolve, CLOSE_TIMEOUT_MS); });
+  try {
+    await Promise.race([session.close().catch(() => undefined), deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export interface Neo4jQueryParams {
   [key: string]: any;
 }
@@ -32,6 +45,8 @@ export class Neo4jClient {
         ...this.convertNestedIntegers(value.properties),
         _id: value.identity.toNumber(),
         _type: value.type,
+        _start: value.start.toNumber(),
+        _end: value.end.toNumber(),
       };
     }
 
@@ -89,7 +104,7 @@ export class Neo4jClient {
       const result: QueryResult = await session.run(query, params);
       return result.records.map((record: Neo4jRecord) => this.recordToObject<T>(record));
     } finally {
-      await session.close();
+      await closeBounded(session);
     }
   }
 
@@ -125,7 +140,7 @@ export class Neo4jClient {
         return rows;
       }, { timeout: options.timeoutMs });
     } finally {
-      await session.close();
+      await closeBounded(session);
     }
   }
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,7 +1,7 @@
 import { cosine } from './embeddings.js';
 import { contentKeys } from './hygiene.js';
 
-export type SearchMode = 'hybrid' | 'keyword' | 'semantic';
+export type SearchMode = 'hybrid' | 'keyword' | 'semantic' | 'exact';
 
 export interface Candidate {
   id: number;
@@ -11,7 +11,15 @@ export interface Candidate {
 export interface Ranked {
   id: number;
   score: number;
-  match: 'keyword' | 'semantic';
+  match: 'keyword' | 'semantic' | 'exact';
+}
+
+/** Case-insensitive equality on name, aliases or email: the lookup to run before creating a memory. */
+export function exactMatches(query: string, props: Record<string, any>): boolean {
+  const wanted = query.trim().toLowerCase();
+  if (!wanted) return false;
+  const values: unknown[] = [props.name, props.email, ...(Array.isArray(props.aliases) ? props.aliases : [])];
+  return values.some((v) => typeof v === 'string' && v.trim().toLowerCase() === wanted);
 }
 
 export function keywordMatches(query: string, props: Record<string, any>): boolean {
@@ -58,6 +66,15 @@ export function rank(candidates: Candidate[], opts: {
 
   const results: Ranked[] = [];
   const seen = new Set<number>();
+
+  if (opts.mode === 'exact') {
+    for (const candidate of candidates) {
+      if (exactMatches(trimmedQuery, candidate.props)) {
+        results.push({ id: candidate.id, score: 1, match: 'exact' });
+      }
+    }
+    return results.sort(compareRankedBy(candidates));
+  }
 
   if (opts.mode === 'hybrid' || opts.mode === 'keyword') {
     for (const candidate of candidates) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,16 @@ import { Neo4jClient } from './neo4j-client.js';
 import { tools } from './tools/definitions.js';
 import { Neo4jServerConfig } from './types.js';
 
+/** A misconfigured provider (missing key, http endpoint…) must not stop the server; search degrades to keyword. */
+function safeCreateEmbedder(): Embedder | null {
+  try {
+    return createEmbedder();
+  } catch (error) {
+    console.error('Embeddings disabled:', error instanceof Error ? error.message : error);
+    return null;
+  }
+}
+
 export class Neo4jServer {
   private server: Server;
   private neo4j: Neo4jClient | null;
@@ -26,7 +36,7 @@ export class Neo4jServer {
     );
 
     this.neo4j = config ? new Neo4jClient(config.uri, config.username, config.password, config.database) : null;
-    this.embedder = config ? createEmbedder() : null;
+    this.embedder = config ? safeCreateEmbedder() : null;
     this.setupToolHandlers();
 
     this.server.onerror = (error) => console.error('[MCP Error]', error);

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -44,14 +44,18 @@ export const tools: Tool[] = [
         },
         search_mode: {
           type: 'string',
-          enum: ['hybrid', 'keyword', 'semantic'],
-          description: 'Search mode: hybrid (default), keyword-only, or semantic-only.',
+          enum: ['hybrid', 'keyword', 'semantic', 'exact'],
+          description: 'Search mode: hybrid (default), keyword-only, semantic-only, or exact (case-insensitive equality on name/aliases/email: use before creating a memory).',
         },
         similarity_threshold: {
           type: 'number',
           minimum: 0,
           maximum: 1,
           description: 'Semantic similarity threshold, 0 to 1 inclusive, defaults to 0.4.',
+        },
+        include_archived: {
+          type: 'boolean',
+          description: 'Include memories with status "archived" (excluded by default).',
         },
       },
       required: [],
@@ -66,7 +70,7 @@ export const tools: Tool[] = [
       properties: {
         label: {
           type: 'string',
-          description: 'Memory label in lowercase (use list_memory_labels first to check existing labels for consistency) - common: person, place, organization, project, event, topic, object, animal, plant, food, activity, media, skill, document, meeting, task, habit, health, vehicle, tool, idea, goal',
+          description: 'Memory label: a plain identifier, Capitalised singular by convention (Person, Place, Organization, Project, Event, Topic, Object, Animal, Concept, Meeting, Decision…). Use list_memory_labels first for consistency; dream canonicalises lowercase labels.',
         },
         properties: {
           type: 'object',
@@ -191,7 +195,12 @@ export const tools: Tool[] = [
     description: 'List all unique memory labels currently in use with their counts (useful for getting an overview of the knowledge graph)',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        include_archived: {
+          type: 'boolean',
+          description: 'Include labels of archived memories (excluded by default).',
+        },
+      },
       required: [],
     },
   },

--- a/src/tools/guidance-tool.ts
+++ b/src/tools/guidance-tool.ts
@@ -51,7 +51,7 @@ export function getGuidanceContent(topic?: string): string {
 
     labels: `## Common Memory Labels
 
-Use these labels when creating memories (always use lowercase):
+Use these labels when creating memories (Capitalised singular is canonical; lowercase is accepted and canonicalised by dream):
 
 **People & Living Things**
 - person: Individual people
@@ -134,7 +134,7 @@ Use UPPERCASE for relationship types:
 - Show distinguishing details: "I found 3 people named John: John Smith (Engineer at Google), John Smith (Doctor), John Smith (Teacher). Which one did you mean?"
 - If unsure about a match, describe it and ask: "I found John Smith who works at TechCorp. Is this the same person?"
 - Only create new memory after confirming it's not a duplicate
-- Always use lowercase for labels
+- Labels are plain identifiers; Capitalised singular is canonical (Person, Organization, Concept)
 - Include a 'name' property for easy identification
 - 'created_at' is automatic if not provided
 - IMMEDIATELY after creating, connect it to related memories
@@ -157,6 +157,8 @@ Use UPPERCASE for relationship types:
 - Empty query string returns all memories
 - Use search_mode: "hybrid" (the default) to return keyword matches first, then semantic matches above the threshold
 - Use search_mode: "keyword" to match any word of the query as a substring of any searchable content property (not timestamps, status or embedding fields), or search_mode: "semantic" for meaning-first recall
+- Use search_mode: "exact" before creating: it matches only a memory whose name, alias or email equals the query, case-insensitively
+- Archived memories are excluded unless include_archived: true
 - Lower similarity_threshold (for example 0.35) to widen semantic matches, or raise it (for example 0.7) to be stricter
 - Results include _score and _match so you can explain why something was returned
 - Use label parameter to filter by type

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,12 +12,13 @@ export interface CreateMemoryArgs {
 
 export interface SearchMemoriesArgs {
   query?: string;
+  include_archived?: boolean;
   label?: string;
   depth?: number;
   order_by?: string;
   limit?: number;
   since_date?: string;
-  search_mode?: 'hybrid' | 'keyword' | 'semantic';
+  search_mode?: 'hybrid' | 'keyword' | 'semantic' | 'exact';
   similarity_threshold?: number;
 }
 
@@ -51,7 +52,7 @@ export interface DeleteConnectionArgs {
 }
 
 export interface ListMemoryLabelsArgs {
-  // No arguments needed for this tool
+  include_archived?: boolean;
 }
 
 export interface QueryMemoriesArgs {
@@ -106,7 +107,7 @@ export function isCreateMemoryArgs(args: unknown): args is CreateMemoryArgs {
     isPlainObject(args.properties);
 }
 
-const SEARCH_KEYS = ['query', 'label', 'depth', 'order_by', 'limit', 'since_date', 'search_mode', 'similarity_threshold'] as const;
+const SEARCH_KEYS = ['query', 'label', 'depth', 'order_by', 'limit', 'since_date', 'search_mode', 'similarity_threshold', 'include_archived'] as const;
 
 export function isSearchMemoriesArgs(args: unknown): args is SearchMemoriesArgs {
   if (!isPlainObject(args) || !hasOnlyKeys(args, SEARCH_KEYS)) return false;
@@ -117,7 +118,8 @@ export function isSearchMemoriesArgs(args: unknown): args is SearchMemoriesArgs 
   if (searchArgs.order_by !== undefined && typeof searchArgs.order_by !== 'string') return false;
   if (searchArgs.limit !== undefined && !isIntegerInRange(searchArgs.limit, 1, SEARCH_MAX_LIMIT)) return false;
   if (searchArgs.since_date !== undefined && typeof searchArgs.since_date !== 'string') return false;
-  if (searchArgs.search_mode !== undefined && !['hybrid', 'keyword', 'semantic'].includes(searchArgs.search_mode)) return false;
+  if (searchArgs.search_mode !== undefined && !['hybrid', 'keyword', 'semantic', 'exact'].includes(searchArgs.search_mode)) return false;
+  if (searchArgs.include_archived !== undefined && typeof searchArgs.include_archived !== 'boolean') return false;
   if (searchArgs.similarity_threshold !== undefined) {
     const threshold = searchArgs.similarity_threshold;
     if (typeof threshold !== 'number' || !Number.isFinite(threshold) || threshold < 0 || threshold > 1) return false;
@@ -163,7 +165,8 @@ export function isDeleteConnectionArgs(args: unknown): args is DeleteConnectionA
 }
 
 export function isListMemoryLabelsArgs(args: unknown): args is ListMemoryLabelsArgs {
-  return typeof args === 'object' && args !== null;
+  return isPlainObject(args) && hasOnlyKeys(args, ['include_archived']) &&
+    (args.include_archived === undefined || typeof args.include_archived === 'boolean');
 }
 
 export function isQueryMemoriesArgs(args: unknown): args is QueryMemoriesArgs {

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -121,6 +121,28 @@ test('keyword search matches any word, ignores timestamps, and honours label cas
   assert.equal(none.length, 0, 'created_at must not be searchable');
 });
 
+test('exact search matches only equality on name, alias or email, case-insensitively', async () => {
+  const hits = await ok('search_memories', { query: 'benjamin weeks', search_mode: 'exact', depth: 0 });
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].memory._match, 'exact');
+  const byEmail = await ok('search_memories', { query: 'BEN@example.com', search_mode: 'exact', depth: 0 });
+  assert.equal(byEmail.length, 1);
+  const partial = await ok('search_memories', { query: 'Benjamin', search_mode: 'exact', depth: 0 });
+  assert.equal(partial.length, 0, 'a partial name is not an exact match');
+});
+
+test('archived memories are hidden from search and label listing unless asked for', async () => {
+  const id = (await ok('create_memory', { label: 'person', properties: { name: 'Old Contact', status: 'archived' } })).memory._id;
+  assert.equal((await ok('search_memories', { query: 'Old Contact', search_mode: 'keyword', depth: 0 })).length, 0);
+  assert.equal((await ok('search_memories', { query: 'Old Contact', search_mode: 'keyword', depth: 0, include_archived: true })).length, 1);
+  const labels = (await ok('list_memory_labels', {}))[0].labels.find((l) => l.label === 'person');
+  assert.equal(labels.count, 1, 'archived node not counted');
+  const all = (await ok('list_memory_labels', { include_archived: true }))[0].labels.find((l) => l.label === 'person');
+  assert.equal(all.count, 2);
+  await fails('list_memory_labels', { verbose: true }, /Invalid list_memory_labels/);
+  await ok('delete_memory', { nodeId: id });
+});
+
 test('semantic search finds Benjamin from "Ben" and reports the semantic match', async () => {
   const hits = await ok('search_memories', { query: 'Ben Weeks', search_mode: 'semantic', depth: 0, similarity_threshold: 0.3 }, 120000);
   const hit = hits.find((h) => h.memory._id === ids.ben);
@@ -133,6 +155,9 @@ test('search returns connections at depth 1 and validates arguments', async () =
   const hits = await ok('search_memories', { query: 'Benjamin', depth: 1 });
   const types = hits[0].connections.map((c) => c.relationship._type).sort();
   assert.deepEqual(types, ['LIVES_IN', 'WORKS_AT']);
+  const worksAt = hits[0].connections.find((c) => c.relationship._type === 'WORKS_AT').relationship;
+  assert.equal(worksAt._start, ids.ben, 'relationship direction is recoverable');
+  assert.equal(worksAt._end, ids.org);
   await fails('search_memories', { query: 'x', limit: -1 }, /Invalid search_memories/);
   await fails('search_memories', { query: 'x', depth: 9 }, /Invalid search_memories/);
   await fails('search_memories', { query: 'x', search_mod: 'semantic' }, /Invalid search_memories/);
@@ -192,6 +217,8 @@ test('dream relabels, merges true duplicates, skips identity conflicts, and flag
   const survivor = orgs.find((o) => o.name === 'Acme');
   assert.equal(survivor.email, 'a@x.com', 'survivor absorbed the merged email');
   assert.equal((await cypher('MATCH (n:organization) RETURN count(n) AS c'))[0].c.toNumber(), 0, 'lowercase label gone');
+  const stale = (await cypher("MATCH (n) WHERE n.embedding_model IS NULL AND coalesce(n.status,'') <> 'archived' RETURN count(n) AS c"))[0].c.toNumber();
+  assert.equal(stale, 0, 'relabelled nodes were re-embedded in the same dream');
   const s = await ok('memory_stats', {});
   if (s.embedder) assert.equal(s.embedded, s.nodes, 'dream re-embedded everything');
 });

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -62,8 +62,8 @@ after(async () => {
   await driver.close();
 });
 
-const ok = async (name, args) => {
-  const r = await mcp.call(name, args);
+const ok = async (name, args, timeoutMs) => {
+  const r = await mcp.call(name, args, timeoutMs);
   assert.ok(r.ok, `${name} failed: ${r.error}`);
   return r.data;
 };
@@ -85,7 +85,7 @@ test('lists the twelve tools', async () => {
 const ids = {};
 
 test('create_memory stamps created_at and returns the node', async () => {
-  const r = await ok('create_memory', { label: 'person', properties: { name: 'Benjamin Weeks', email: 'ben@example.com', role: 'Founder' } });
+  const r = await ok('create_memory', { label: 'person', properties: { name: 'Benjamin Weeks', email: 'ben@example.com', aliases: ['Ben W'], role: 'Founder' } });
   assert.equal(r.memory.name, 'Benjamin Weeks');
   assert.match(r.memory.created_at, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(typeof r.memory._id, 'number');
@@ -127,6 +127,8 @@ test('exact search matches only equality on name, alias or email, case-insensiti
   assert.equal(hits[0].memory._match, 'exact');
   const byEmail = await ok('search_memories', { query: 'BEN@example.com', search_mode: 'exact', depth: 0 });
   assert.equal(byEmail.length, 1);
+  const byAlias = await ok('search_memories', { query: 'ben w', search_mode: 'exact', depth: 0 });
+  assert.equal(byAlias.length, 1, 'an alias is an exact match regardless of case');
   const partial = await ok('search_memories', { query: 'Benjamin', search_mode: 'exact', depth: 0 });
   assert.equal(partial.length, 0, 'a partial name is not an exact match');
 });

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -140,6 +140,12 @@ test('archived memories are hidden from search and label listing unless asked fo
   const all = (await ok('list_memory_labels', { include_archived: true }))[0].labels.find((l) => l.label === 'person');
   assert.equal(all.count, 2);
   await fails('list_memory_labels', { verbose: true }, /Invalid list_memory_labels/);
+  // an archived neighbour does not appear in another memory's connections either
+  await ok('create_connection', { fromMemoryId: ids.ben, toMemoryId: id, type: 'KNOWS' });
+  const ben = (await ok('search_memories', { query: 'Benjamin', search_mode: 'keyword', depth: 1 }))[0];
+  assert.ok(!ben.connections.some((c) => c.memory._id === id), 'archived neighbour hidden');
+  const benAll = (await ok('search_memories', { query: 'Benjamin', search_mode: 'keyword', depth: 1, include_archived: true }))[0];
+  assert.ok(benAll.connections.some((c) => c.memory._id === id), 'archived neighbour shown when asked');
   await ok('delete_memory', { nodeId: id });
 });
 

--- a/tests/unit.test.mjs
+++ b/tests/unit.test.mjs
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 import { cosine, createEmbedder, embeddingText, nameText, scrub } from '../build/embeddings.js';
-import { keywordMatches, rank } from '../build/search.js';
+import { exactMatches, keywordMatches, rank } from '../build/search.js';
 import { contentKeys, factLikeKeys, maxProperties } from '../build/hygiene.js';
 import { readOnlyViolation, stripComments } from '../build/cypher-guard.js';
 import { cypherIdentifier, isCreateConnectionArgs, isCreateMemoryArgs, isDreamArgs, isMemoryStatsArgs, isQueryMemoriesArgs, isSearchMemoriesArgs } from '../build/types.js';
@@ -98,6 +98,10 @@ function approxEqual(actual, expected, epsilon = 1e-9) {
 
   assert.strictEqual(nameText('Person', { name: 'Ben Weeks', aliases: ['Benjamin'], context: 'ignored' }), 'Person: Ben Weeks\naliases: Benjamin');
 
+  assert.strictEqual(exactMatches('ben weeks', { name: 'Ben Weeks' }), true);
+  assert.strictEqual(exactMatches('Ben', { name: 'Benjamin Weeks', aliases: ['Ben'] }), true);
+  assert.strictEqual(exactMatches('Ben', { name: 'Benjamin Weeks' }), false);
+  assert.deepStrictEqual(rank([{ id: 1, props: { name: 'Ben Weeks' } }, { id: 2, props: { name: 'Benjamin Weeks' } }], { query: 'ben weeks', mode: 'exact', threshold: 0.4 }).map((r) => [r.id, r.match]), [[1, 'exact']]);
   assert.strictEqual(keywordMatches('Ben Weeks', { name: 'Benjamin' }), true);
   assert.strictEqual(keywordMatches('Benjamin', { name: 'Ben' }), false);
 
@@ -129,6 +133,12 @@ function approxEqual(actual, expected, epsilon = 1e-9) {
   assert.ok(readOnlyViolation("CALL /* hi */ apoc.load.json('http://169.254.169.254/') YIELD value RETURN value"));
   assert.ok(readOnlyViolation("CALL // c\n apoc.create.node(['X'], {}) YIELD node RETURN node"));
   assert.strictEqual(readOnlyViolation('CALL /* fine */ db.labels() YIELD label RETURN label'), null);
+  // a // inside a string literal is not a comment and cannot hide what follows it
+  assert.ok(readOnlyViolation("WITH 'https://example.test' AS x CALL apoc.load.json(x) YIELD value RETURN value"));
+  assert.ok(readOnlyViolation('WITH "http://a//b" AS x CALL apoc.load.json(x) YIELD value RETURN value'));
+  // keywords inside strings are not clauses
+  assert.strictEqual(readOnlyViolation("MATCH (n) WHERE n.note = 'please DELETE this' RETURN n"), null);
+  assert.strictEqual(readOnlyViolation("MATCH (n) WHERE n.name = 'It''s // not a comment' RETURN n"), null);
   assert.strictEqual(stripComments('MATCH (n) // trailing\nRETURN n /* block */'), 'MATCH (n)  \nRETURN n  ');
 
   // labels and relationship types are identifiers; anything else is rejected before it reaches Cypher


### PR DESCRIPTION
## Summary

Server-side follow-ups requested by the Hermes thin-client integration (hermes-reverie #7) plus the valid points from CodeRabbit's last pass on #16:

- **`search_mode: "exact"`**: case-insensitive equality on `name`, `aliases` or `email`; the precise lookup to run before creating a memory (replaces the client's paged keyword scan).
- **Archived hidden by default**: `search_memories` and `list_memory_labels` exclude `status = 'archived'` unless `include_archived: true`; `list_memory_labels` arguments validated strictly.
- **Relationship endpoints**: results carry `_start`/`_end` node ids so neighbour direction is recoverable.
- **Guard hardening**: the read-only Cypher guard tokenises string literals and backtick identifiers, so a `//` inside a quoted URL cannot hide a `CALL apoc.load.json(...)` from validation; keywords inside strings no longer false-positive.
- **dream**: relabelling clears `embedding_model` so relabelled nodes are re-embedded in the same pass.
- **Robustness**: bounded `session.close()`; a misconfigured embedding provider logs and degrades to keyword instead of stopping the server.
- **Docs**: labels are Capitalised singular identifiers (tool description, guidance, README); threshold wording; tool count is 12.

Deferred, tracked separately: bounding the candidate scan before ranking (needs a Cypher-side scoring pass for semantic mode).

Stacked on #18 (targets `test/integration-suite`); retarget to `main` after #18 merges, before its branch is deleted.

Fixes #2

## Test plan

- [x] `npm run test:coverage` against a throwaway `neo4j:5-community` + APOC container: 18 tests pass (four new: exact mode, archived exclusion and label listing, relationship endpoints, relabel re-embedding), coverage 89% lines
- [x] Unit tests cover the string-literal bypass and keyword-in-string false positive on the guard, and exact matching on name/alias/email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds exact, case-insensitive search and archived-memory filtering for Hermes thin-client integration. It also hardens Cypher validation, adds relationship endpoint metadata, improves embedding and session failure handling, and clears stale embedding metadata during re-embedding.

## Worth a look

- **Design decision:** Exact matching checks names, emails, and aliases instead of using semantic ranking (`src/search.ts`). Confirm this meets duplicate-prevention needs.
- **Subtle behaviour:** Archived memories are excluded by default and require `include_archived` (`src/handlers/index.ts`).
- **Security-sensitive change:** `stripComments` masks strings and backtick identifiers before read-only Cypher validation (`src/cypher-guard.ts`).
- **Operational limits:** Embedder failures fall back to keyword search, while session cleanup stops waiting after five seconds (`src/server.ts`, `src/neo4j-client.ts`). Confirm these limits match deployment requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->