### PR TITLE
chore: one-off workflow to deprecate the old npm package name

### DIFF
--- a/.github/workflows/deprecate-old-package.yml
+++ b/.github/workflows/deprecate-old-package.yml
@@ -19,12 +19,18 @@ jobs:
   deprecate:
     name: npm deprecate
     runs-on: ubuntu-latest
+    concurrency:
+      group: deprecate-old-package
+      cancel-in-progress: false
     steps:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - run: npm deprecate @knowall-ai/mcp-neo4j-agent-memory "$MESSAGE"
+      # An empty message would UN-deprecate the package, so refuse it.
+      - run: |
+          if [ -z "${MESSAGE// }" ]; then echo "message must not be empty"; exit 1; fi
+          npm deprecate @knowall-ai/mcp-neo4j-agent-memory "$MESSAGE"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           MESSAGE: ${{ inputs.message }}

--- a/.github/workflows/deprecate-old-package.yml
+++ b/.github/workflows/deprecate-old-package.yml
@@ -1,0 +1,31 @@
+name: Deprecate old package name
+
+# One-off utility: marks @knowall-ai/mcp-neo4j-agent-memory deprecated on npm with a
+# pointer to @knowall-ai/reverie. Run manually from the Actions tab (workflow_dispatch).
+# Uses the same NPM_TOKEN automation token as release.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: Deprecation message shown by npm
+        required: true
+        default: "Renamed to @knowall-ai/reverie - install that instead"
+
+permissions:
+  contents: read
+
+jobs:
+  deprecate:
+    name: npm deprecate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm deprecate @knowall-ai/mcp-neo4j-agent-memory "$MESSAGE"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MESSAGE: ${{ inputs.message }}
+      - run: npm view @knowall-ai/mcp-neo4j-agent-memory deprecated


### PR DESCRIPTION
## Summary

Adds a manually dispatched workflow that runs `npm deprecate` on the old package name `@knowall-ai/mcp-neo4j-agent-memory` with a message pointing users to `@knowall-ai/reverie`. The npm web UI only sets the generic "no longer supported" text and the CLI needs a 2FA code, so the existing `NPM_TOKEN` automation token used by release.yml is the practical route.

- `workflow_dispatch` only, with a `message` input (default points at the new package).
- `permissions: contents: read`; the token is only exposed to the deprecate step.
- Prints `npm view … deprecated` afterwards so the run log shows the result.
- Kept as a utility so the message can be updated later without a local npm login.

## Test plan

- [ ] CI, gitleaks and PR lint green on this PR (the workflow itself does not run on PRs).
- [ ] After merge, dispatch from the Actions tab and confirm the final step prints the new deprecation message.
- [ ] `npm view @knowall-ai/mcp-neo4j-agent-memory deprecated` shows the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a manually triggered workflow to deprecate `@knowall-ai/mcp-neo4j-agent-memory` and direct users to `@knowall-ai/reverie`. It validates the message, serialises runs, limits permissions, and verifies the published deprecation message.

## Worth a look

- Confirm that `NPM_TOKEN` has only the required npm access. It is exposed to the deprecation step in `.github/workflows/deprecate-old-package.yml`.
- Confirm that maintainers should provide arbitrary deprecation messages. A fixed message would reduce the risk of misleading public package metadata.
- Treat the operation as a public package-metadata change. Verify the package name and default message before enabling maintainer access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->