### PR TITLE
chore: list Reverie in the MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 # Publishes a tagged version: `git tag v0.4.0 && git push origin v0.4.0`.
 # - npm: @knowall-ai/reverie with provenance (needs the NPM_TOKEN secret, an npm automation token)
 # - GHCR: ghcr.io/knowall-ai/mcp-reverie:<version> and :latest (uses the built-in GITHUB_TOKEN)
+# - MCP Registry: io.github.knowall-ai/reverie (GitHub OIDC, no secret; runs after the npm publish
+#   because the registry verifies ownership via the published package's mcpName field)
 # Smithery redeploys from the repository on its own schedule; trigger a redeploy from the
 # Smithery dashboard after a release if the listing lags.
 
@@ -87,3 +89,29 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  registry:
+    name: Publish to the MCP Registry
+    needs: npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # GitHub OIDC login to registry.modelcontextprotocol.io
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install mcp-publisher (pinned, checksum-verified)
+        run: |
+          curl -sSL -o mcp-publisher.tar.gz \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+          echo "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+      - name: server.json version must match the tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          for v in "$(jq -r .version server.json)" "$(jq -r '.packages[0].version' server.json)"; do
+            if [ "$v" != "$tag" ]; then echo "::error::server.json version $v does not match tag v$tag"; exit 1; fi
+          done
+      - run: ./mcp-publisher login github-oidc
+      - run: ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN npm run build
 
 # Use a lightweight Node.js image for the final build
 FROM node:22-alpine
+LABEL io.modelcontextprotocol.server.name="io.github.knowall-ai/reverie"
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 
 ## Installation
 
+### MCP Registry
+
+Reverie is listed in the [MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.knowall-ai/reverie` (the successor of the "Neo4j Agent Memory" entry that used to sit in the modelcontextprotocol/servers README). `server.json` in this repository is the listing; the release workflow republishes it on every tag.
+
 ### Installing via Smithery
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@knowall-ai/reverie",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Reverie — graph memory that dreams. Graph-based memory system for AI agents. Store people, places, organizations as nodes. Build semantic relationships (KNOWS, WORKS_AT, CREATED). Hybrid keyword + semantic search finds partial matches and close variants. Filter by date, traverse relationships, maintain temporal context. Simple tools, LLM handles complexity. 12 tools for complete memory management.",
+  "mcpName": "io.github.knowall-ai/reverie",
   "type": "module",
   "module": "./src/index.ts",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.knowall-ai/reverie",
+  "title": "Reverie",
+  "description": "Graph memory that dreams: Neo4j knowledge-graph memory for AI agents with hybrid search",
+  "websiteUrl": "https://github.com/knowall-ai/mcp-reverie#readme",
+  "repository": {
+    "url": "https://github.com/knowall-ai/mcp-reverie",
+    "source": "github"
+  },
+  "version": "0.5.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@knowall-ai/reverie",
+      "version": "0.5.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "NEO4J_URI",
+          "description": "Bolt URI of the Neo4j 5 database, e.g. bolt://localhost:7687",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "NEO4J_USERNAME",
+          "description": "Neo4j user",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "NEO4J_PASSWORD",
+          "description": "Neo4j password",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "NEO4J_DATABASE",
+          "description": "Database name (Enterprise only; omit on Community Edition)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "REVERIE_EMBEDDINGS",
+          "description": "Embedding provider for semantic search: local (default, no API key), openai, azure, ollama, voyage or none",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The "Neo4j Agent Memory" entry (knowall-ai/mcp-neo4j-agent-memory) in the modelcontextprotocol/servers README cannot be renamed: that whole community list was retired on 2026-04-14 (commit 5914f61, "retire third-party server list in favor of MCP Registry"). The replacement is the [MCP Registry](https://registry.modelcontextprotocol.io/), where Reverie is not yet listed. This PR lists it.

- `server.json`: the listing (`io.github.knowall-ai/reverie`, npm package `@knowall-ai/reverie`, stdio, env vars documented), validated against the 2025-12-11 schema.
- `package.json`: `mcpName` (the registry verifies npm ownership through it) and version 0.5.1, because the published 0.5.0 tarball predates the field.
- `Dockerfile`: `io.modelcontextprotocol.server.name` label so the GHCR image can be added to the listing in a later release.
- `release.yml`: a `registry` job after the npm publish, GitHub OIDC login (no secret), `mcp-publisher` v1.8.1 pinned with a sha256 check, and a guard that server.json's version matches the tag.
- README: short "MCP Registry" note.

After merge: tag `v0.5.1` → npm (with mcpName) → registry entry appears. Smithery still shows the old package name; that redeploy is a dashboard action.

## Test plan

- [x] `server.json` passes the official schema (jsonschema, 0 errors).
- [x] Build, unit and startup tests green locally.
- [ ] CI green (the registry job only runs on tags).
- [ ] After `v0.5.1`: `curl https://registry.modelcontextprotocol.io/v0/servers?search=knowall` lists `io.github.knowall-ai/reverie`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds Reverie to the MCP Registry as `io.github.knowall-ai/reverie`. It adds the registry manifest, release publication workflow, version checks, package metadata, and Docker labelling.

## Worth a look

- **Release security:** `.github/workflows/release.yml` downloads and verifies the pinned `mcp-publisher` binary, then uses GitHub OIDC. Confirm the checksum and trust boundary.
- **Release failure handling:** The registry job runs after npm publication. Confirm whether a registry failure should fail an already-published release.
- **Configuration accuracy:** `server.json` documents Neo4j and embedding-provider variables. Confirm these match the runtime requirements.
- **Validation gap:** CI and post-release registry verification remain pending. Treat this as a blocker before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->