### PR TITLE
chore: registry listing under the knowall.ai domain namespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Release
 # Publishes a tagged version: `git tag v0.4.0 && git push origin v0.4.0`.
 # - npm: @knowall-ai/reverie with provenance (needs the NPM_TOKEN secret, an npm automation token)
 # - GHCR: ghcr.io/knowall-ai/mcp-reverie:<version> and :latest (uses the built-in GITHUB_TOKEN)
-# - MCP Registry: io.github.knowall-ai/reverie (GitHub OIDC, no secret; runs after the npm publish
-#   because the registry verifies ownership via the published package's mcpName field)
+# - MCP Registry: ai.knowall/reverie under the knowall.ai domain namespace (DNS-verified: the apex
+#   TXT record "v=MCPv1; k=ed25519; p=…" plus the MCP_REGISTRY_PRIVATE_KEY secret); runs after the
+#   npm publish because the registry verifies ownership via the published package's mcpName field
 # Smithery redeploys from the repository on its own schedule; trigger a redeploy from the
 # Smithery dashboard after a release if the listing lags.
 
@@ -96,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write   # GitHub OIDC login to registry.modelcontextprotocol.io
+      id-token: write   # kept for npm provenance parity; the registry login is DNS-based
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,5 +114,8 @@ jobs:
           for v in "$(jq -r .version server.json)" "$(jq -r '.packages[0].version' server.json)"; do
             if [ "$v" != "$tag" ]; then echo "::error::server.json version $v does not match tag v$tag"; exit 1; fi
           done
-      - run: ./mcp-publisher login github-oidc
+      - name: Log in to the registry as knowall.ai (DNS namespace)
+        run: ./mcp-publisher login dns --domain=knowall.ai --private-key="$MCP_REGISTRY_PRIVATE_KEY"
+        env:
+          MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
       - run: ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN npm run build
 
 # Use a lightweight Node.js image for the final build
 FROM node:22-alpine
-LABEL io.modelcontextprotocol.server.name="io.github.knowall-ai/reverie"
+LABEL io.modelcontextprotocol.server.name="ai.knowall/reverie"
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This server now supports connecting to specific databases in Neo4j Enterprise Ed
 
 ### MCP Registry
 
-Reverie is listed in the [MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.knowall-ai/reverie` (the successor of the "Neo4j Agent Memory" entry that used to sit in the modelcontextprotocol/servers README). `server.json` in this repository is the listing; the release workflow republishes it on every tag.
+Reverie is listed in the [MCP Registry](https://registry.modelcontextprotocol.io/) as `ai.knowall/reverie` (KnowAll's domain namespace, verified by a DNS TXT record on knowall.ai) (the successor of the "Neo4j Agent Memory" entry that used to sit in the modelcontextprotocol/servers README). `server.json` in this repository is the listing; the release workflow republishes it on every tag.
 
 ### Installing via Smithery
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@knowall-ai/reverie",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Reverie — graph memory that dreams. Graph-based memory system for AI agents. Store people, places, organizations as nodes. Build semantic relationships (KNOWS, WORKS_AT, CREATED). Hybrid keyword + semantic search finds partial matches and close variants. Filter by date, traverse relationships, maintain temporal context. Simple tools, LLM handles complexity. 12 tools for complete memory management.",
-  "mcpName": "io.github.knowall-ai/reverie",
+  "mcpName": "ai.knowall/reverie",
   "type": "module",
   "module": "./src/index.ts",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.knowall-ai/reverie",
+  "name": "ai.knowall/reverie",
   "title": "Reverie",
   "description": "Graph memory that dreams: Neo4j knowledge-graph memory for AI agents with hybrid search",
   "websiteUrl": "https://github.com/knowall-ai/mcp-reverie#readme",
@@ -8,13 +8,13 @@
     "url": "https://github.com/knowall-ai/mcp-reverie",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@knowall-ai/reverie",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Moves the MCP Registry listing from the GitHub-org namespace (`io.github.knowall-ai/reverie`) to KnowAll's domain namespace, `ai.knowall/reverie` (the registry's mandatory `namespace/server` form; the namespace is the reverse of knowall.ai).

- `server.json`, `package.json` (`mcpName`), `Dockerfile` label: new name; version 0.5.2 so the next npm publish carries it.
- `release.yml`: the registry job logs in with `mcp-publisher login dns --domain=knowall.ai` using the `MCP_REGISTRY_PRIVATE_KEY` secret (Ed25519, already set) instead of GitHub OIDC.
- README note updated.

**Do not merge until the DNS TXT record is live on the apex of knowall.ai** (Microsoft 365 admin centre → Domains → knowall.ai → DNS records → TXT, host `@`), otherwise the registry job fails at login. After merge: tag `v0.5.2`, then deprecate the old `io.github.knowall-ai/reverie` entry with `mcp-publisher status --status deprecated`.

## Test plan

- [x] `server.json` passes the 2025-12-11 schema.
- [ ] `dig +short TXT knowall.ai` shows the `v=MCPv1; k=ed25519; p=…` record.
- [ ] `mcp-publisher login dns --domain=knowall.ai` succeeds locally with the same key.
- [ ] After `v0.5.2`: registry search for `knowall` lists `ai.knowall/reverie` 0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYWpYQfhw84PHmaKQYopn